### PR TITLE
Allow deleting the last to-do

### DIFF
--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -2,7 +2,7 @@
 
 jQuery( document ).ready( function () {
 	const saveTodoList = () => {
-		const todoList = [];
+		let todoList = [];
 
 		jQuery( '#todo-list li' ).each( function () {
 			todoList.push( {
@@ -12,6 +12,10 @@ jQuery( document ).ready( function () {
 					.prop( 'checked' ),
 			} );
 		} );
+
+		if ( todoList.length === 0 ) {
+			todoList = 'empty';
+		}
 
 		// Save the todo list to the database
 		jQuery.post( progressPlannerTodo.ajaxUrl, {

--- a/classes/class-todo.php
+++ b/classes/class-todo.php
@@ -71,7 +71,7 @@ class Todo {
 
 		if ( $_POST['todo_list'] === 'empty' ) {
 			\delete_option( self::OPTION_NAME );
-			\wp_send_json_success( [ 'message' => \esc_html__( 'Saved.', 'progress-planner' ) ] );	
+			\wp_send_json_success( [ 'message' => \esc_html__( 'Saved.', 'progress-planner' ) ] );
 		}
 
 		$items          = [];

--- a/classes/class-todo.php
+++ b/classes/class-todo.php
@@ -69,6 +69,11 @@ class Todo {
 			\wp_send_json_error( [ 'message' => \esc_html__( 'Missing data.', 'progress-planner' ) ] );
 		}
 
+		if ( $_POST['todo_list'] === 'empty' ) {
+			\delete_option( self::OPTION_NAME );
+			\wp_send_json_success( [ 'message' => \esc_html__( 'Saved.', 'progress-planner' ) ] );	
+		}
+
 		$items          = [];
 		$previous_items = self::get_items();
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Allow deleting the last to-do.

## Relevant technical choices:

* Added an `empty` response when there are no to-do's, so that A the actual value is not empty and can thus be parsed properly in the function, and B we can identify that it's an empty to-do list now.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different browsers

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have checked that the base branch is correctly set.

Fixes #30
