### PR TITLE
Fix uninstall functionality

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,0 +1,16 @@
+name: Playground Comment
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            **Test on Playground**
+            [Test this pull request on the Playground](https://playground.wordpress.net/#{"landingPage":"/wp-admin/edit-tags.php?taxonomy=post_tag","features":{"networking":true},"steps":[{"step":"defineWpConfigConsts","consts":{"IS_PLAYGROUND_PREVIEW":true}},{"step":"login","username":"admin","password":"password"},{"step":"installPlugin","pluginZipFile":{"resource":"url","url":"https://bypass-cors.altha.workers.dev/${{ github.server_url }}/${{ github.repository }}/archive/${{ github.sha }}.zip"},"options":{"activate":true}}]})

--- a/uninstall.php
+++ b/uninstall.php
@@ -12,8 +12,8 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-require_once __DIR__ . '/includes/class-settings.php';
-require_once __DIR__ . '/includes/class-query.php';
+require_once __DIR__ . '/classes/class-settings.php';
+require_once __DIR__ . '/classes/class-query.php';
 
 /**
  * Delete the plugin options.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Fixed where `uninstall.php` loads files from, prevents a fatal error on uninstall.

## Test instructions
1. Use playground.wordpress.net to test deleting the plugin in current released version, see it errors.
2. Test this version using the below playground comment.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have checked that the base branch is correctly set.

Fixes #34 