### PR TITLE
No longer show the password reset link during onboarding

### DIFF
--- a/assets/js/onboard.js
+++ b/assets/js/onboard.js
@@ -28,12 +28,10 @@ const progressPlannerAjaxAPIRequest = ( data ) => {
 		url: progressPlanner.onboardAPIUrl,
 		data,
 		successAction: ( response ) => {
-			// Show link to reset password.
+			// Show success message.
 			document.getElementById(
-				'prpl-password-reset-link'
+				'prpl-account-created-message'
 			).style.display = 'block';
-			document.getElementById( 'prpl-password-reset-link' ).href =
-				response.password_reset_url;
 
 			// Hide the form.
 			document.getElementById( 'prpl-onboarding-form' ).style.display =

--- a/classes/class-onboard.php
+++ b/classes/class-onboard.php
@@ -146,9 +146,9 @@ class Onboard {
 		</form>
 
 		<div>
-			<a style="display:none;" id="prpl-password-reset-link">
-				<?php \esc_html_e( 'Registration successful. Set your password now and edit your profile', 'progress-planner' ); ?>
-			</a>
+			<p id="prpl-account-created-message" style="display:none;">
+				<?php printf( \esc_html__( 'Success! We created an account for you on %s so we can email you every week.', 'progress-planner' ), '<a href="https://progressplanner.com/">ProgressPlanner.com</a>' ); ?>
+			</p>
 			<div id="progress-planner-scan-progress" style="display:none;">
 				<progress value="0" max="100"></progress>
 			</div>

--- a/classes/class-onboard.php
+++ b/classes/class-onboard.php
@@ -147,7 +147,10 @@ class Onboard {
 
 		<div>
 			<p id="prpl-account-created-message" style="display:none;">
-				<?php printf( \esc_html__( 'Success! We created an account for you on %s so we can email you every week.', 'progress-planner' ), '<a href="https://progressplanner.com/">ProgressPlanner.com</a>' ); ?>
+				<?php
+				// translators: %s: progressplanner.com link.
+				printf( \esc_html__( 'Success! We created an account for you on %s so we can email you every week.', 'progress-planner' ), '<a href="https://progressplanner.com/">ProgressPlanner.com</a>' );
+				?>
 			</p>
 			<div id="progress-planner-scan-progress" style="display:none;">
 				<progress value="0" max="100"></progress>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to not show the password reset link as we go through the process of fixing #31 

## Summary

This PR can be summarized in the following changelog entry:

* No longer show links to reset password, only show a link to ProgressPlanner.com.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have checked that the base branch is correctly set.

Relates to #31
