### PR TITLE
To-do list accessibility

### DIFF
--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -5,12 +5,18 @@ jQuery( document ).ready( function () {
 		const todoList = [];
 
 		jQuery( '#todo-list li' ).each( function () {
+			const content = jQuery( this ).find( '.content' ).text();
+
 			todoList.push( {
-				content: jQuery( this ).find( '.content' ).text(),
+				content: content,
 				done: jQuery( this )
 					.find( 'input[type="checkbox"]' )
 					.prop( 'checked' ),
 			} );
+
+			// Update aria-labels
+			jQuery( this ).find( 'input[type="checkbox"]' ).attr( 'aria-label', content );
+			jQuery( this ).find( '.trash' ).attr( 'aria-label', `Delete task '${ content }'` );
 		} );
 
 		// Save the todo list to the database
@@ -56,9 +62,9 @@ jQuery( document ).ready( function () {
 					<path d="M8 7h2V5H8v2zm0 6h2v-2H8v2zm0 6h2v-2H8v2zm6-14v2h2V5h-2zm0 8h2v-2h-2v2zm0 6h2v-2h-2v2z"></path>
 				</svg>
 			</span>
-			<input type="checkbox" ${ done ? 'checked' : '' }>
+			<input type="checkbox" aria-label="'${ content }'" ${ done ? 'checked' : '' }>
 			<span class="content" contenteditable="plaintext-only">${ content }</span>
-			<button class="trash"><span class="dashicons dashicons-trash"></span></button>
+			<button class="trash" aria-label="'${ content }'"><span class="dashicons dashicons-trash"></span></button>
 		` );
 
 		if ( addToStart ) {

--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -1,6 +1,10 @@
 /* global progressPlannerTodo, jQuery */
 
 jQuery( document ).ready( function () {
+	const announce = (message) => {
+		jQuery('#todo-aria-live-region').text(message);
+	};
+	
 	const saveTodoList = () => {
 		const todoList = [];
 
@@ -123,6 +127,10 @@ jQuery( document ).ready( function () {
 			! todoItemDone,
 			true // Save.
 		);
+
+		// Announce the status change and move focus to the moved item
+		const status = todoItemDone ? 'completed and moved to the bottom' : 'marked as not completed and moved to the top';
+		announce(`Task '${todoItemContent}' ${status}`);
 	} );
 
 	// When an item's contenteditable element is edited,

--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -133,7 +133,20 @@ jQuery( document ).ready( function () {
 
 	// When the trash button is clicked, remove the todo item from the list
 	jQuery( '#todo-list' ).on( 'click', '.trash', function () {
-		jQuery( this ).closest( 'li' ).remove();
+		const todoItem = jQuery( this ).closest( 'li' );
+		const nextItem = todoItem.next('li');
+		const prevItem = todoItem.prev('li');
+
+		todoItem.remove();
 		saveTodoList();
+
+		// Shift focus to the next item if available, otherwise to the previous item, otherwise to the input field
+		if (nextItem.length) {
+			nextItem.find('input[type="checkbox"]').focus();
+		} else if (prevItem.length) {
+			prevItem.find('input[type="checkbox"]').focus();
+		} else {
+			jQuery('#new-todo-content').focus();
+		}
 	} );
 } );

--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -73,6 +73,11 @@ jQuery( document ).ready( function () {
 			jQuery( '#todo-list' ).append( todoItemElement );
 		}
 
+		// Focus the new task's content element after it is added to the DOM
+		setTimeout(() => {
+			todoItemElement.find('input[type="checkbox"]').focus();
+		}, 0);
+
 		if ( save ) {
 			saveTodoList();
 		}

--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -64,7 +64,7 @@ jQuery( document ).ready( function () {
 			</span>
 			<input type="checkbox" aria-label="'${ content }'" ${ done ? 'checked' : '' }>
 			<span class="content" contenteditable="plaintext-only">${ content }</span>
-			<button class="trash" aria-label="'${ content }'"><span class="dashicons dashicons-trash"></span></button>
+			<button class="trash" aria-label="Delete task '${ content }'"><span class="dashicons dashicons-trash"></span></button>
 		` );
 
 		if ( addToStart ) {

--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -1,10 +1,9 @@
 /* global progressPlannerTodo, jQuery */
 
 jQuery( document ).ready( function () {
-	const announce = (message) => {
-		jQuery('#todo-aria-live-region').text(message);
+	const announce = ( message ) => {
+		jQuery( '#todo-aria-live-region' ).text( message );
 	};
-	
 	const saveTodoList = () => {
 		const todoList = [];
 
@@ -12,15 +11,19 @@ jQuery( document ).ready( function () {
 			const content = jQuery( this ).find( '.content' ).text();
 
 			todoList.push( {
-				content: content,
+				content,
 				done: jQuery( this )
 					.find( 'input[type="checkbox"]' )
 					.prop( 'checked' ),
 			} );
 
 			// Update aria-labels
-			jQuery( this ).find( 'input[type="checkbox"]' ).attr( 'aria-label', content );
-			jQuery( this ).find( '.trash' ).attr( 'aria-label', `Delete task '${ content }'` );
+			jQuery( this )
+				.find( 'input[type="checkbox"]' )
+				.attr( 'aria-label', content );
+			jQuery( this )
+				.find( '.trash' )
+				.attr( 'aria-label', `Delete task '${ content }'` );
 		} );
 
 		// Save the todo list to the database
@@ -78,9 +81,9 @@ jQuery( document ).ready( function () {
 		}
 
 		// Focus the new task's content element after it is added to the DOM
-		setTimeout(() => {
-			todoItemElement.find('input[type="checkbox"]').focus();
-		}, 0);
+		setTimeout( () => {
+			todoItemElement.find( 'input[type="checkbox"]' ).focus();
+		}, 0 );
 
 		if ( save ) {
 			saveTodoList();
@@ -129,8 +132,10 @@ jQuery( document ).ready( function () {
 		);
 
 		// Announce the status change and move focus to the moved item
-		const status = todoItemDone ? 'completed and moved to the bottom' : 'marked as not completed and moved to the top';
-		announce(`Task '${todoItemContent}' ${status}`);
+		const status = todoItemDone
+			? 'completed and moved to the bottom'
+			: 'marked as not completed and moved to the top';
+		announce( `Task '${ todoItemContent }' ${ status }` );
 	} );
 
 	// When an item's contenteditable element is edited,
@@ -142,19 +147,19 @@ jQuery( document ).ready( function () {
 	// When the trash button is clicked, remove the todo item from the list
 	jQuery( '#todo-list' ).on( 'click', '.trash', function () {
 		const todoItem = jQuery( this ).closest( 'li' );
-		const nextItem = todoItem.next('li');
-		const prevItem = todoItem.prev('li');
+		const nextItem = todoItem.next( 'li' );
+		const prevItem = todoItem.prev( 'li' );
 
 		todoItem.remove();
 		saveTodoList();
 
 		// Shift focus to the next item if available, otherwise to the previous item, otherwise to the input field
-		if (nextItem.length) {
-			nextItem.find('input[type="checkbox"]').focus();
-		} else if (prevItem.length) {
-			prevItem.find('input[type="checkbox"]').focus();
+		if ( nextItem.length ) {
+			nextItem.find( 'input[type="checkbox"]' ).focus();
+		} else if ( prevItem.length ) {
+			prevItem.find( 'input[type="checkbox"]' ).focus();
 		} else {
-			jQuery('#new-todo-content').focus();
+			jQuery( '#new-todo-content' ).focus();
 		}
 	} );
 } );

--- a/classes/widgets/class-todo.php
+++ b/classes/widgets/class-todo.php
@@ -56,7 +56,7 @@ final class ToDo extends Widget {
 		<ul id="todo-list" class="prpl-todo-list"></ul>
 
 		<form id="create-todo-item">
-			<input type="text" id="new-todo-content" placeholder="<?php esc_attr_e( 'Add a new task', 'progress-planner' ); ?>" required />
+			<input type="text" id="new-todo-content" placeholder="<?php esc_attr_e( 'Add a new task', 'progress-planner' ); ?>" aria-label="<?php esc_attr_e( 'Add a new task', 'progress-planner' ); ?>" required />
 			<button type="submit" title="<?php esc_attr_e( 'Add', 'progress-planner' ); ?>">
 				<span class="dashicons dashicons-plus-alt2"></span>
 			</button>

--- a/classes/widgets/class-todo.php
+++ b/classes/widgets/class-todo.php
@@ -53,6 +53,8 @@ final class ToDo extends Widget {
 	 */
 	public static function the_todo_list() {
 		?>
+		<div id="todo-aria-live-region" aria-live="polite" style="position: absolute; left: -9999px;"></div>
+
 		<ul id="todo-list" class="prpl-todo-list"></ul>
 
 		<form id="create-todo-item">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR adds accessibility improvements to the To-do list. This fixes the missing form labels and empty button while improving focus positioning and giving context to dynamic content.

https://github.com/Emilia-Capital/progress-planner/assets/2895788/4ae95738-b9d4-446d-a5d7-064f42573a51

## Summary

This PR can be summarized in the following changelog entry:

- Added: an `aria-label` to the `new-todo-content` input as it was missing a form label. To be fully accessible a visual input is required. That will require some layout changes and can be handled in a future PR.
- Added: an `aria-label` to the todo checkboxes and the trash button and ensured these label update if the todo content updates.
- Updated: focus position to shift to newly added todos so that they read out to the screen reader
- Updated: focus position when trashing todos. Focus logic will shift to either the next todo item if it exist, or the previous todo item if it exist and final if neither exists it will shift focus back to the `new-todo-content` input.
- Added: aria-live region to announce the position shift to the screener to give users context when a todo is shifted up or down in the todos list.

## Relevant technical choices:

* Made focus shift choices based on what gave the screen reader the most context. Aimed not to be verbose and over utilize `aria-live`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

Accessibility issues can be found by running an accessibility evaluation tool such as the WAVE browser extension.
<img width="1099" alt="Screenshot 2024-06-09 at 10 50 55 PM" src="https://github.com/Emilia-Capital/progress-planner/assets/2895788/248c6611-e7be-4e15-9210-2660d775741b">


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [x] Changes should be tested with screen readers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
