### PR TITLE
Fix responsive styles for the dashboard widget

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -980,8 +980,12 @@ button.prpl-info-icon {
 \*------------------------------------*/
 #progress_planner_dashboard_widget_score .prpl-dashboard-widget {
 	display: grid;
-	grid-template-columns: 55% 1px 30%;
+	grid-template-columns: 1fr 1px 140px;
 	grid-gap: calc(var(--prpl-gap) / 2);
+}
+
+#progress_planner_dashboard_widget_score .prpl-activities-gauge-container {
+	padding-bottom: calc(var(--prpl-padding) * 2);
 }
 
 #progress_planner_dashboard_widget_score .prpl-badge-wrapper {
@@ -1060,6 +1064,10 @@ button.prpl-info-icon {
 	font-size: var(--prpl-font-size-base);
 	color: var(--prpl-color-gray-5);
 	margin-top: -15px;
+}
+
+#progress_planner_dashboard_widget_score .prpl-gauge-number {
+	font-size: var(--prpl-font-size-4xl);
 }
 
 /*------------------------------------*\


### PR DESCRIPTION
## Context
Before:
<img width="392" alt="Screenshot 2024-06-10 at 12 05 55 PM" src="https://github.com/Emilia-Capital/progress-planner/assets/588688/72ef6f49-64b3-4a9d-a3f9-4706f50cb964">

AFter:
<img width="392" alt="Screenshot 2024-06-10 at 12 06 20 PM" src="https://github.com/Emilia-Capital/progress-planner/assets/588688/bb2bf74b-daad-4c06-9f9f-f989c05c663d">

## Summary

This PR can be summarized in the following changelog entry:

* Fix responsive styles for the dashboard widget

## Relevant technical choices:

* Changed the grid columns
* Reduced the font-size of the score. I thought of using a responsive/adaptive font-size, but that won't work because the widget doesn't scale proportionally to the screen size, as the dashboard widgets container columns change.
* Increased the bottom padding so that the 0/100 numbers don't get cut off.

## Test instructions
Should be tested by resizing the browser and checking that in all scenarios, the content is readable and looks OK.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] I have checked that the base branch is correctly set.
