### PR TITLE
Fix deploy flow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,44 @@
-name: "Deploy to WordPress.org"
+name: Deploy to WordPress.org repository
 
 on: 
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [released]
 
 jobs:
-  tag:
-    name: New tag
+  deploy_to_wordpress_org:
+    name: Deploy release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - name: WordPress Plugin Deploy
+      # Checkout the code
+      - name: Checkout code
+        uses: actions/checkout@v4
+      # Optional: if we add a build step to the plugin, we can run it here.
+      # Deploy the plugin to WordPress.org
+      - name: WordPress plugin deploy
+        id: deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
+        with:
+          generate-zip: true
         env:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+      # After the deploy, we also want to create a zip and upload it to the release on Github. We don't want
+      # users to have to go to the repository to find our plugin :).
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          # Note, this is an exception to action secrets: GH_TOKEN is always available and provides access to
+          # the current repository this action runs in.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Get the URL for uploading assets to the current release.
+          upload_url: ${{ github.event.release.upload_url }}
+
+          # Provide the path to the file generated in the previous step using the output and the id of the step.
+          asset_path: ${{ steps.deploy.outputs.zip-path }}
+
+          # Provide what the file should be named when attached to the release (plugin-name.zip)
+          asset_name: ${{ github.event.repository.name }}.zip
+
+          # Provide the file type.
+          asset_content_type: application/zip


### PR DESCRIPTION
Switch from a deploy flow that deploys to WordPress.org on committing a tag, to a deploy flow that deploys to WordPress.org on creating the release on GitHub.