### PR TITLE
Skip rendering badges that are complete

### DIFF
--- a/classes/badges/class-badge.php
+++ b/classes/badges/class-badge.php
@@ -48,7 +48,7 @@ abstract class Badge {
 
 	/**
 	 * Get the badge ID.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function get_id() {

--- a/classes/badges/class-badge.php
+++ b/classes/badges/class-badge.php
@@ -47,6 +47,15 @@ abstract class Badge {
 	}
 
 	/**
+	 * Get the badge ID.
+	 * 
+	 * @return string
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+
+	/**
 	 * Get the badge name.
 	 *
 	 * @return string

--- a/classes/class-badges.php
+++ b/classes/class-badges.php
@@ -30,6 +30,9 @@ class Badges {
 	 * @return void
 	 */
 	public static function register_badge( $badge_id, $args ) {
+		if ( ! isset( $args['id'] ) ) {
+			$args['id'] = $badge_id;
+		}
 		self::$badges[ $badge_id ] = $args;
 	}
 

--- a/classes/widgets/class-badge-content.php
+++ b/classes/widgets/class-badge-content.php
@@ -23,7 +23,7 @@ final class Badge_Content extends Widget {
 
 	/**
 	 * Whether we should render the widget or not.
-	 * 
+	 *
 	 * @return bool
 	 */
 	protected function should_render() {

--- a/classes/widgets/class-badge-content.php
+++ b/classes/widgets/class-badge-content.php
@@ -22,6 +22,22 @@ final class Badge_Content extends Widget {
 	protected $id = 'badge-content';
 
 	/**
+	 * Whether we should render the widget or not.
+	 * 
+	 * @return bool
+	 */
+	protected function should_render() {
+		$details = $this->get_badge_details();
+		if (
+			'awesome-author' === $details['badge']['id']
+			&& 100 === (int) $details['progress']['progress']
+		) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Render the widget content.
 	 *
 	 * @return void
@@ -78,7 +94,10 @@ final class Badge_Content extends Widget {
 	 * @return array
 	 */
 	public function get_badge_details() {
-		$result = [];
+		static $result = [];
+		if ( ! empty( $result ) ) {
+			return $result;
+		}
 		$badges = [ 'wonderful-writer', 'bold-blogger', 'awesome-author' ];
 
 		// Get the badge to display.

--- a/classes/widgets/class-badge-content.php
+++ b/classes/widgets/class-badge-content.php
@@ -28,13 +28,7 @@ final class Badge_Content extends Widget {
 	 */
 	protected function should_render() {
 		$details = $this->get_badge_details();
-		if (
-			'awesome-author' === $details['badge']['id']
-			&& 100 === (int) $details['progress']['progress']
-		) {
-			return false;
-		}
-		return true;
+		return ( 100 > (int) $details['progress']['progress'] );
 	}
 
 	/**

--- a/classes/widgets/class-badge-streak.php
+++ b/classes/widgets/class-badge-streak.php
@@ -22,9 +22,9 @@ final class Badge_Streak extends Widget {
 	 */
 	protected $id = 'badge-streak';
 
-/**
+	/**
 	 * Whether we should render the widget or not.
-	 * 
+	 *
 	 * @return bool
 	 */
 	protected function should_render() {
@@ -37,7 +37,7 @@ final class Badge_Streak extends Widget {
 		}
 		return true;
 	}
-	
+
 	/**
 	 * Render the widget content.
 	 *

--- a/classes/widgets/class-badge-streak.php
+++ b/classes/widgets/class-badge-streak.php
@@ -22,6 +22,22 @@ final class Badge_Streak extends Widget {
 	 */
 	protected $id = 'badge-streak';
 
+/**
+	 * Whether we should render the widget or not.
+	 * 
+	 * @return bool
+	 */
+	protected function should_render() {
+		$details = $this->get_badge_details();
+		if (
+			'super-site-specialist' === $details['badge']['id']
+			&& 100 === (int) $details['progress']['progress']
+		) {
+			return false;
+		}
+		return true;
+	}
+	
 	/**
 	 * Render the widget content.
 	 *
@@ -79,7 +95,10 @@ final class Badge_Streak extends Widget {
 	 * @return array
 	 */
 	public function get_badge_details() {
-		$result = [];
+		static $result = [];
+		if ( ! empty( $result ) ) {
+			return $result;
+		}
 		$badges = [
 			'progress-padawan',
 			'maintenance-maniac',

--- a/classes/widgets/class-badge-streak.php
+++ b/classes/widgets/class-badge-streak.php
@@ -29,13 +29,7 @@ final class Badge_Streak extends Widget {
 	 */
 	protected function should_render() {
 		$details = $this->get_badge_details();
-		if (
-			'super-site-specialist' === $details['badge']['id']
-			&& 100 === (int) $details['progress']['progress']
-		) {
-			return false;
-		}
-		return true;
+		return ( 100 > (int) $details['progress']['progress'] );
 	}
 
 	/**

--- a/classes/widgets/class-widget.php
+++ b/classes/widgets/class-widget.php
@@ -68,7 +68,7 @@ abstract class Widget {
 
 	/**
 	 * Whether we should render the widget or not.
-	 * 
+	 *
 	 * @return bool
 	 */
 	protected function should_render() {

--- a/classes/widgets/class-widget.php
+++ b/classes/widgets/class-widget.php
@@ -58,9 +58,21 @@ abstract class Widget {
 	 * @return void
 	 */
 	protected function render() {
+		if ( ! $this->should_render() ) {
+			return;
+		}
 		echo '<div class="prpl-widget-wrapper prpl-' . \esc_attr( $this->id ) . '">';
 		$this->the_content();
 		echo '</div>';
+	}
+
+	/**
+	 * Whether we should render the widget or not.
+	 * 
+	 * @return bool
+	 */
+	protected function should_render() {
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Context
If all badges are complete, we should not display the separate badge-progress widgets.

## Relevant technical choices:

* Added a `should_render()` method for widgets. If all badges are complete, then this method will return false.
* Added caching in the `get_badge_details()` methods using a static var to avoid re-calculating things.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes #
