### PR TITLE
Improve conditions for latest-badge detection

### DIFF
--- a/classes/class-badges.php
+++ b/classes/class-badges.php
@@ -95,7 +95,7 @@ class Badges {
 			$badge_progress = self::get_badge_progress( $badge_id );
 
 			// Skip if the badge is not completed.
-			if ( 100 !== $badge_progress['progress'] ) {
+			if ( 100 > (int) $badge_progress['progress'] ) {
 				continue;
 			}
 
@@ -114,7 +114,7 @@ class Badges {
 			}
 
 			// Compare dates.
-			if ( \DateTime::createFromFormat( 'Y-m-d H:i:s', $settings[ $badge_id ]['date'] )->format( 'U' ) > \DateTime::createFromFormat( 'Y-m-d H:i:s', $latest_date )->format( 'U' ) ) {
+			if ( \DateTime::createFromFormat( 'Y-m-d H:i:s', $settings[ $badge_id ]['date'] )->format( 'U' ) >= \DateTime::createFromFormat( 'Y-m-d H:i:s', $latest_date )->format( 'U' ) ) {
 				$latest_date = $settings[ $badge_id ]['date'];
 				$latest_id   = $badge_id;
 			}


### PR DESCRIPTION
## Context

Today we came across a new edge-case:
When badges get completed at the same time (like for example if 300 new posts get inserted at the same time), we can't properly detect the latest badge.

## Summary

This PR can be summarized in the following changelog entry:

* Fixed a condition, changing the `DateTime` check from `>` to `>=` to account for the above scenario

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
