### PR TITLE
Add a settings popover to exclude post-types from tracking

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -130,6 +130,12 @@ button.prpl-info-icon {
 	height: 100px;
 }
 
+.prpl-header-right {
+	display: flex;
+	gap: var(--prpl-padding);
+	align-items: center;
+}
+
 /*------------------------------------*\
 	Charts container.
 \*------------------------------------*/
@@ -1087,4 +1093,19 @@ button.prpl-info-icon {
 
 #prpl-dashboard-widget-todo-header p, #todo-list li {
 	font-size: 14px;
+}
+
+/*------------------------------------*\
+	Settings popup.
+\*------------------------------------*/
+.popup-settings-wrapper label {
+	display: block;
+}
+
+.popup-settings-wrapper form p {
+	max-width: 42em;
+}
+
+.popup-settings-wrapper form button.button-primary {
+	margin-top: 1em;
 }

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1098,14 +1098,18 @@ button.prpl-info-icon {
 /*------------------------------------*\
 	Settings popup.
 \*------------------------------------*/
-.popup-settings-wrapper label {
+#prpl-settings-form label {
 	display: block;
 }
 
-.popup-settings-wrapper form p {
+#prpl-settings-form p {
 	max-width: 42em;
 }
 
-.popup-settings-wrapper form button.button-primary {
+#prpl-settings-form h3 {
+	font-size: 1.15em;
+}
+
+#prpl-settings-form button.button-primary {
 	margin-top: 1em;
 }

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,7 +1,7 @@
 document.getElementById( 'prpl-settings-form' ).addEventListener( 'submit', function( event ) {
 	event.preventDefault();
 	const form = new FormData( this );
-	const data = form.getAll( 'prpl-settings-post-types-exclude[]' );
+	const data = form.getAll( 'prpl-settings-post-types-include[]' );
 
 	// Save the options.
 	progressPlannerAjaxRequest( {
@@ -10,9 +10,9 @@ document.getElementById( 'prpl-settings-form' ).addEventListener( 'submit', func
 			action: 'progress_planner_save_cpt_settings',
 			_ajax_nonce: progressPlanner.nonce,
 			include_post_types: data,
-		}
+		},
 	} );
 
-	document.getElementById( 'submit-exclude-post-types' ).disabled = true;
-	document.getElementById( 'submit-exclude-post-types' ).innerHTML = progressPlanner.l10n.saved;
+	document.getElementById( 'submit-include-post-types' ).disabled = true;
+	document.getElementById( 'submit-include-post-types' ).innerHTML = progressPlanner.l10n.saved;
 } );

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,0 +1,18 @@
+document.getElementById( 'prpl-settings-form' ).addEventListener( 'submit', function( event ) {
+	event.preventDefault();
+	const form = new FormData( this );
+	const data = form.getAll( 'prpl-settings-post-types-exclude[]' );
+
+	// Save the options.
+	progressPlannerAjaxRequest( {
+		url: progressPlanner.ajaxUrl,
+		data: {
+			action: 'progress_planner_save_cpt_settings',
+			_ajax_nonce: progressPlanner.nonce,
+			exclude_post_types: data,
+		}
+	} );
+
+	document.getElementById( 'submit-exclude-post-types' ).disabled = true;
+	document.getElementById( 'submit-exclude-post-types' ).innerHTML = progressPlanner.l10n.saved;
+} );

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -9,7 +9,7 @@ document.getElementById( 'prpl-settings-form' ).addEventListener( 'submit', func
 		data: {
 			action: 'progress_planner_save_cpt_settings',
 			_ajax_nonce: progressPlanner.nonce,
-			exclude_post_types: data,
+			include_post_types: data,
 		}
 	} );
 

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -11,8 +11,11 @@ document.getElementById( 'prpl-settings-form' ).addEventListener( 'submit', func
 			_ajax_nonce: progressPlanner.nonce,
 			include_post_types: data,
 		},
+		successAction: () => {
+			window.location.reload();
+		},
 	} );
 
 	document.getElementById( 'submit-include-post-types' ).disabled = true;
-	document.getElementById( 'submit-include-post-types' ).innerHTML = progressPlanner.l10n.saved;
+	document.getElementById( 'submit-include-post-types' ).innerHTML = progressPlanner.l10n.saving;
 } );

--- a/classes/activities/class-content-helpers.php
+++ b/classes/activities/class-content-helpers.php
@@ -22,18 +22,14 @@ class Content_Helpers {
 	 * @return string[]
 	 */
 	public static function get_post_types_names() {
-		$post_types = \get_post_types( [ 'public' => true ] );
-		$post_types = \array_filter( $post_types, 'is_post_type_viewable' );
-		unset( $post_types['attachment'] );
-		unset( $post_types['elementor_library'] ); // Elementor templates are not a post type we want to track.
-
-		// Get an array of post-types we want to exclude, and remove them from the array.
-		$exclude_post_types = Settings::get( [ 'exclude_post_types' ], [] );
-		foreach ( $exclude_post_types as $post_type ) {
-			unset( $post_types[ $post_type ] );
-		}
-
-		return array_keys( $post_types );
+		$default            = [ 'post', 'page' ];
+		$include_post_types = \array_filter(
+			Settings::get( [ 'include_post_types' ], $default ),
+			function( $post_type ) {
+				return $post_type && \post_type_exists( $post_type ) && is_post_type_viewable( $post_type );
+			}
+		);
+		return empty( $include_post_types ) ? $default : \array_values( $include_post_types );
 	}
 
 	/**

--- a/classes/activities/class-content-helpers.php
+++ b/classes/activities/class-content-helpers.php
@@ -27,6 +27,12 @@ class Content_Helpers {
 		unset( $post_types['attachment'] );
 		unset( $post_types['elementor_library'] ); // Elementor templates are not a post type we want to track.
 
+		// Get an array of post-types we want to exclude, and remove them from the array.
+		$exclude_post_types = Settings::get( [ 'exclude_post_types' ], [] );
+		foreach ( $exclude_post_types as $post_type ) {
+			unset( $post_types[ $post_type ] );
+		}
+
 		return array_keys( $post_types );
 	}
 

--- a/classes/activities/class-content-helpers.php
+++ b/classes/activities/class-content-helpers.php
@@ -25,7 +25,7 @@ class Content_Helpers {
 		$default            = [ 'post', 'page' ];
 		$include_post_types = \array_filter(
 			Settings::get( [ 'include_post_types' ], $default ),
-			function( $post_type ) {
+			function ( $post_type ) {
 				return $post_type && \post_type_exists( $post_type ) && is_post_type_viewable( $post_type );
 			}
 		);

--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -228,8 +228,8 @@ class Page {
 			$localize_data,
 			[
 				'l10n' => [
-					'saved' => \esc_html__( 'Saved' )
-				]
+					'saved' => \esc_html__( 'Saved', 'progress-planner' ),
+				],
 			]
 		);
 		\wp_localize_script( 'progress-planner-settings', 'progressPlanner', $localize_data_settings );

--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -283,9 +283,9 @@ class Page {
 	 */
 	public function save_cpt_settings() {
 		\check_ajax_referer( 'progress_planner', 'nonce', false );
-		$exclude_post_types = isset( $_POST['exclude_post_types'] ) ? \sanitize_text_field( \wp_unslash( $_POST['exclude_post_types'] ) ) : '';
-		$exclude_post_types = \explode( ',', $exclude_post_types );
-		\Progress_Planner\Settings::set( 'exclude_post_types', $exclude_post_types );
+		$include_post_types = isset( $_POST['include_post_types'] ) ? \sanitize_text_field( \wp_unslash( $_POST['include_post_types'] ) ) : 'post,page';
+		$include_post_types = \explode( ',', $include_post_types );
+		\Progress_Planner\Settings::set( 'include_post_types', $include_post_types );
 
 		\wp_send_json_success(
 			[

--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -60,6 +60,7 @@ class Page {
 	private function register_hooks() {
 		\add_action( 'admin_menu', [ $this, 'add_page' ] );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+		\add_action( 'wp_ajax_progress_planner_save_cpt_settings', [ $this, 'save_cpt_settings' ] );
 	}
 
 	/**
@@ -187,6 +188,15 @@ class Page {
 			true
 		);
 
+		// Register the admin script for the settings popup.
+		\wp_register_script(
+			'progress-planner-settings',
+			PROGRESS_PLANNER_URL . '/assets/js/settings.js',
+			[ 'progress-planner-ajax' ],
+			filemtime( PROGRESS_PLANNER_DIR . '/assets/js/settings.js' ),
+			true
+		);
+
 		// Register the admin script for the page.
 		\wp_register_script(
 			'progress-planner-admin',
@@ -214,6 +224,15 @@ class Page {
 		// Localize the scripts.
 		\wp_localize_script( 'progress-planner-onboard', 'progressPlanner', $localize_data );
 		\wp_localize_script( 'progress-planner-admin', 'progressPlanner', $localize_data );
+		$localize_data_settings = array_merge(
+			$localize_data,
+			[
+				'l10n' => [
+					'saved' => \esc_html__( 'Saved' )
+				]
+			]
+		);
+		\wp_localize_script( 'progress-planner-settings', 'progressPlanner', $localize_data_settings );
 		\wp_localize_script(
 			'progress-planner-todo',
 			'progressPlannerTodo',
@@ -240,6 +259,7 @@ class Page {
 		\wp_enqueue_script( 'progress-planner-onboard' );
 		\wp_enqueue_script( 'progress-planner-admin' );
 		\wp_enqueue_script( 'progress-planner-todo' );
+		\wp_enqueue_script( 'progress-planner-settings' );
 	}
 
 	/**
@@ -253,6 +273,24 @@ class Page {
 			PROGRESS_PLANNER_URL . '/assets/css/admin.css',
 			[],
 			filemtime( PROGRESS_PLANNER_DIR . '/assets/css/admin.css' )
+		);
+	}
+
+	/**
+	 * Save the post types settings.
+	 *
+	 * @return void
+	 */
+	public function save_cpt_settings() {
+		\check_ajax_referer( 'progress_planner', 'nonce', false );
+		$exclude_post_types = isset( $_POST['exclude_post_types'] ) ? \sanitize_text_field( \wp_unslash( $_POST['exclude_post_types'] ) ) : '';
+		$exclude_post_types = \explode( ',', $exclude_post_types );
+		\Progress_Planner\Settings::set( 'exclude_post_types', $exclude_post_types );
+
+		\wp_send_json_success(
+			[
+				'message' => \esc_html__( 'Settings saved.', 'progress-planner' ),
+			]
 		);
 	}
 }

--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -228,7 +228,7 @@ class Page {
 			$localize_data,
 			[
 				'l10n' => [
-					'saved' => \esc_html__( 'Saved', 'progress-planner' ),
+					'saving' => \esc_html__( 'Saving...', 'progress-planner' ),
 				],
 			]
 		);

--- a/classes/popups/class-popup.php
+++ b/classes/popups/class-popup.php
@@ -27,18 +27,28 @@ abstract class Popup {
 	}
 
 	/**
-	 * Render the widget content.
+	 * Render the triggering button.
 	 *
 	 * @return void
 	 */
-	public function render() {
+	public function render_button() {
 		?>
 		<!-- The triggering button. -->
 		<button class="prpl-info-icon" popovertarget="prpl-popover-<?php echo \esc_attr( $this->id ); ?>">
 			<span class="dashicons dashicons-info-outline"></span>
 			<span class="screen-reader-text"><?php \esc_html_e( 'More info', 'progress-planner' ); ?>
 		</button>
+		<?php
+	}
 
+	/**
+	 * Render the widget content.
+	 *
+	 * @return void
+	 */
+	public function render() {
+		?>
+		<?php $this->render_button(); ?>
 		<div id="prpl-popover-<?php echo \esc_attr( $this->id ); ?>" class="prpl-popover" popover>
 			<!-- The content. -->
 			<?php $this->the_content(); ?>

--- a/classes/popups/class-settings.php
+++ b/classes/popups/class-settings.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Settings popup.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Popups;
+
+/**
+ * Settings popup.
+ */
+final class Settings extends Popup {
+
+	/**
+	 * The popover ID.
+	 *
+	 * @var string
+	 */
+	protected $id = 'settings';
+
+	/**
+	 * Render the triggering button.
+	 *
+	 * @return void
+	 */
+	public function render_button() {
+		?>
+		<!-- The triggering button. -->
+		<button class="prpl-info-icon" popovertarget="prpl-popover-<?php echo \esc_attr( $this->id ); ?>">
+			<span class="dashicons dashicons-admin-generic"></span>
+			<span class="screen-reader-text"><?php \esc_html_e( 'Settings', 'progress-planner' ); ?>
+		</button>
+		<?php
+	}
+
+	/**
+	 * Render the widget content.
+	 *
+	 * @return void
+	 */
+	protected function the_content() {
+		$saved_settings = \Progress_Planner\Settings::get( 'exclude_post_types', [] );
+		$post_types     = \array_filter( \get_post_types( [ 'public' => true ] ), 'is_post_type_viewable' );
+		unset( $post_types['attachment'] );
+		unset( $post_types['elementor_library'] ); // Elementor templates are not a post type we want to track.
+		?>
+
+		<h2><?php \esc_html_e( 'Settings', 'progress-planner' ); ?></h2>
+
+		<div class="prpl-widgets-container">
+			<div class="prpl-widget-wrapper popup-settings-wrapper">
+				<form id="prpl-settings-form">
+					<h3><?php \esc_html_e( 'Exclude Post Types', 'progress-planner' ) ?></h3>
+					<p><?php \esc_html_e( 'Select the post types you want to exclude from activity scores. This setting will affect which post-type activities get tracked.', 'progress-planner' ); ?></p>
+					<?php foreach ( $post_types as $post_type ) : ?>
+						<label>
+							<input
+								type="checkbox"
+								name="prpl-settings-post-types-exclude[]"
+								value="<?php echo \esc_attr( $post_type ); ?>"
+								<?php checked( \in_array( $post_type, $saved_settings, true ) ); ?>
+							/>
+							<?php echo \esc_html( \get_post_type_object( $post_type )->labels->name ); ?>
+						</label>
+					<?php endforeach; ?>
+
+					<button id="submit-exclude-post-types" class="button button-primary"><?php \esc_html_e( 'Save', 'progress-planner' ); ?></button>
+				</form>
+			</div>
+		</div>
+		<?php
+	}
+}

--- a/classes/popups/class-settings.php
+++ b/classes/popups/class-settings.php
@@ -51,7 +51,7 @@ final class Settings extends Popup {
 		<div class="prpl-widgets-container">
 			<div class="prpl-widget-wrapper popup-settings-wrapper">
 				<form id="prpl-settings-form">
-					<h3><?php \esc_html_e( 'Exclude Post Types', 'progress-planner' ) ?></h3>
+					<h3><?php \esc_html_e( 'Exclude Post Types', 'progress-planner' ); ?></h3>
 					<p><?php \esc_html_e( 'Select the post types you want to exclude from activity scores. This setting will affect which post-type activities get tracked.', 'progress-planner' ); ?></p>
 					<?php foreach ( $post_types as $post_type ) : ?>
 						<label>

--- a/classes/popups/class-settings.php
+++ b/classes/popups/class-settings.php
@@ -57,7 +57,7 @@ final class Settings extends Popup {
 				<label>
 					<input
 						type="checkbox"
-						name="prpl-settings-post-types-exclude[]"
+						name="prpl-settings-post-types-include[]"
 						value="<?php echo \esc_attr( $post_type ); ?>"
 						<?php checked( \in_array( $post_type, $saved_settings, true ) ); ?>
 					/>
@@ -65,7 +65,7 @@ final class Settings extends Popup {
 				</label>
 			<?php endforeach; ?>
 
-			<button id="submit-exclude-post-types" class="button button-primary"><?php \esc_html_e( 'Save', 'progress-planner' ); ?></button>
+			<button id="submit-include-post-types" class="button button-primary"><?php \esc_html_e( 'Save', 'progress-planner' ); ?></button>
 		</form>
 		<?php
 	}

--- a/classes/popups/class-settings.php
+++ b/classes/popups/class-settings.php
@@ -7,6 +7,8 @@
 
 namespace Progress_Planner\Popups;
 
+use Progress_Planner\Activities\Content_Helpers;
+
 /**
  * Settings popup.
  */
@@ -40,7 +42,7 @@ final class Settings extends Popup {
 	 * @return void
 	 */
 	protected function the_content() {
-		$saved_settings = \Progress_Planner\Settings::get( 'exclude_post_types', [] );
+		$saved_settings = Content_Helpers::get_post_types_names();
 		$post_types     = \array_filter( \get_post_types( [ 'public' => true ] ), 'is_post_type_viewable' );
 		unset( $post_types['attachment'] );
 		unset( $post_types['elementor_library'] ); // Elementor templates are not a post type we want to track.
@@ -49,8 +51,8 @@ final class Settings extends Popup {
 		<h2><?php \esc_html_e( 'Settings', 'progress-planner' ); ?></h2>
 
 		<form id="prpl-settings-form">
-			<h3><?php \esc_html_e( 'Exclude Post Types', 'progress-planner' ); ?></h3>
-			<p><?php \esc_html_e( 'Select the post types you want to exclude from activity scores. This setting will affect which post-type activities get tracked.', 'progress-planner' ); ?></p>
+			<h3><?php \esc_html_e( 'Post Types', 'progress-planner' ); ?></h3>
+			<p><?php \esc_html_e( 'Select the post types you want to include in activity scores. This setting will affect which post-type activities get tracked.', 'progress-planner' ); ?></p>
 			<?php foreach ( $post_types as $post_type ) : ?>
 				<label>
 					<input

--- a/classes/popups/class-settings.php
+++ b/classes/popups/class-settings.php
@@ -48,27 +48,23 @@ final class Settings extends Popup {
 
 		<h2><?php \esc_html_e( 'Settings', 'progress-planner' ); ?></h2>
 
-		<div class="prpl-widgets-container">
-			<div class="prpl-widget-wrapper popup-settings-wrapper">
-				<form id="prpl-settings-form">
-					<h3><?php \esc_html_e( 'Exclude Post Types', 'progress-planner' ); ?></h3>
-					<p><?php \esc_html_e( 'Select the post types you want to exclude from activity scores. This setting will affect which post-type activities get tracked.', 'progress-planner' ); ?></p>
-					<?php foreach ( $post_types as $post_type ) : ?>
-						<label>
-							<input
-								type="checkbox"
-								name="prpl-settings-post-types-exclude[]"
-								value="<?php echo \esc_attr( $post_type ); ?>"
-								<?php checked( \in_array( $post_type, $saved_settings, true ) ); ?>
-							/>
-							<?php echo \esc_html( \get_post_type_object( $post_type )->labels->name ); ?>
-						</label>
-					<?php endforeach; ?>
+		<form id="prpl-settings-form">
+			<h3><?php \esc_html_e( 'Exclude Post Types', 'progress-planner' ); ?></h3>
+			<p><?php \esc_html_e( 'Select the post types you want to exclude from activity scores. This setting will affect which post-type activities get tracked.', 'progress-planner' ); ?></p>
+			<?php foreach ( $post_types as $post_type ) : ?>
+				<label>
+					<input
+						type="checkbox"
+						name="prpl-settings-post-types-exclude[]"
+						value="<?php echo \esc_attr( $post_type ); ?>"
+						<?php checked( \in_array( $post_type, $saved_settings, true ) ); ?>
+					/>
+					<?php echo \esc_html( \get_post_type_object( $post_type )->labels->name ); ?>
+				</label>
+			<?php endforeach; ?>
 
-					<button id="submit-exclude-post-types" class="button button-primary"><?php \esc_html_e( 'Save', 'progress-planner' ); ?></button>
-				</form>
-			</div>
-		</div>
+			<button id="submit-exclude-post-types" class="button button-primary"><?php \esc_html_e( 'Save', 'progress-planner' ); ?></button>
+		</form>
 		<?php
 	}
 }

--- a/views/admin-page-header.php
+++ b/views/admin-page-header.php
@@ -24,45 +24,48 @@ $progress_planner_active_frequency = isset( $_GET['frequency'] ) ? \sanitize_tex
 		?>
 	</div>
 
-	<div class="prpl-header-select-range">
-		<label for="prpl-select-range" class="screen-reader-text">
-			<?php \esc_html_e( 'Select range:', 'progress-planner' ); ?>
-		</label>
-		<select id="prpl-select-range">
-			<?php
-			foreach ( [
-				'-3 months'  => \esc_html__( 'Activity over the past 3 months', 'progress-planner' ),
-				'-6 months'  => \esc_html__( 'Activity over the past 6 months', 'progress-planner' ),
-				'-12 months' => \esc_html__( 'Activity over the past 12 months', 'progress-planner' ),
-				'-18 months' => \esc_html__( 'Activity over the past 18 months', 'progress-planner' ),
-				'-24 months' => \esc_html__( 'Activity over the past 24 months', 'progress-planner' ),
-			] as $progress_planner_range => $progress_planner_label ) {
-				printf(
-					'<option value="%1$s" %2$s>%3$s</option>',
-					\esc_attr( $progress_planner_range ),
-					\selected( $progress_planner_active_range, $progress_planner_range, false ),
-					\esc_html( $progress_planner_label )
-				);
-			}
-			?>
-		</select>
-		<label for="prpl-select-frequency" class="screen-reader-text">
-			<?php \esc_html_e( 'Select frequency:', 'progress-planner' ); ?>
-		</label>
-		<select id="prpl-select-frequency">
-			<?php
-			foreach ( [
-				'weekly'  => \esc_html__( 'Weekly', 'progress-planner' ),
-				'monthly' => \esc_html__( 'Monthly', 'progress-planner' ),
-			] as $progress_planner_frequency => $progress_planner_label ) {
-				printf(
-					'<option value="%1$s" %2$s>%3$s</option>',
-					\esc_attr( $progress_planner_frequency ),
-					\selected( $progress_planner_active_frequency, $progress_planner_frequency, false ),
-					\esc_html( $progress_planner_label )
-				);
-			}
-			?>
-		</select>
+	<div class="prpl-header-right">
+		<?php new \Progress_Planner\Popups\Settings(); ?>
+		<div class="prpl-header-select-range">
+			<label for="prpl-select-range" class="screen-reader-text">
+				<?php \esc_html_e( 'Select range:', 'progress-planner' ); ?>
+			</label>
+			<select id="prpl-select-range">
+				<?php
+				foreach ( [
+					'-3 months'  => \esc_html__( 'Activity over the past 3 months', 'progress-planner' ),
+					'-6 months'  => \esc_html__( 'Activity over the past 6 months', 'progress-planner' ),
+					'-12 months' => \esc_html__( 'Activity over the past 12 months', 'progress-planner' ),
+					'-18 months' => \esc_html__( 'Activity over the past 18 months', 'progress-planner' ),
+					'-24 months' => \esc_html__( 'Activity over the past 24 months', 'progress-planner' ),
+				] as $progress_planner_range => $progress_planner_label ) {
+					printf(
+						'<option value="%1$s" %2$s>%3$s</option>',
+						\esc_attr( $progress_planner_range ),
+						\selected( $progress_planner_active_range, $progress_planner_range, false ),
+						\esc_html( $progress_planner_label )
+					);
+				}
+				?>
+			</select>
+			<label for="prpl-select-frequency" class="screen-reader-text">
+				<?php \esc_html_e( 'Select frequency:', 'progress-planner' ); ?>
+			</label>
+			<select id="prpl-select-frequency">
+				<?php
+				foreach ( [
+					'weekly'  => \esc_html__( 'Weekly', 'progress-planner' ),
+					'monthly' => \esc_html__( 'Monthly', 'progress-planner' ),
+				] as $progress_planner_frequency => $progress_planner_label ) {
+					printf(
+						'<option value="%1$s" %2$s>%3$s</option>',
+						\esc_attr( $progress_planner_frequency ),
+						\selected( $progress_planner_active_frequency, $progress_planner_frequency, false ),
+						\esc_html( $progress_planner_label )
+					);
+				}
+				?>
+			</select>
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Context

This PR adds a popover for settings, to allow excluding post-types from tracking.

The settings popover was added to the header, right next to the months selector:

<img width="1165" alt="Screenshot 2024-07-08 at 11 11 12 AM" src="https://github.com/Emilia-Capital/progress-planner/assets/588688/99272784-80e0-494b-9a29-811db9bb7484">

Initially, I wanted to add a setting to select which post-types will be _included_, however that would lead to lots of complications if post-types get added later. With that in mind, it seemed a better option to add a setting to _exclude_ post-types.
To avoid designing a new page etc, it seemed better to reuse the popover API we already implement - especially since we only have 1 option. If in the future we add more options, we may want to rethink that approach

<img width="1165" alt="Screenshot 2024-07-08 at 11 42 09 AM" src="https://github.com/Emilia-Capital/progress-planner/assets/588688/f4cc1cee-ae67-458b-9302-642311cffad9">

## Summary

This PR can be summarized in the following changelog entry:

* Add settings popover to exclude post-types from tracking.

## Relevant technical choices:

* Used an AJAX call to save the options, to avoid reloading the page. 

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.