### PR TITLE
Fix graph filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-= 0.9.5 =
+= - in development =
 
 Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+= 0.9.5 =
+
+Fixed:
+
+* Post-type filters intruduced in v0.9.4 now also affect the graph results.
+
+= 0.9.4 =
+
+Enhancements:
+
+* Added a setting to include post types, we default to `post` and `page` and you can add others as you wish.
+
+Fixed:
+
+* Completing the last badge wouldn't ever work, fixed.
+* Fixed some bugs around detecting badges being "had".
+* Replaced links to the site with shortlinks, so we can change them as needed without doing a release.
+
 = 0.9.3 =
 
 Security:

--- a/classes/widgets/class-published-content-density.php
+++ b/classes/widgets/class-published-content-density.php
@@ -81,7 +81,25 @@ final class Published_Content_Density extends Widget {
 			],
 			'count_callback' => [ $this, 'count_density' ],
 			'compound'       => false,
+			'filter_results' => [ $this, 'filter_activities' ],
 		];
+	}
+
+	/**
+	 * Callback to filter the activities.
+	 *
+	 * @param \Progress_Planner\Activities\Content[] $activities The activities array.
+	 *
+	 * @return \Progress_Planner\Activities\Content[]
+	 */
+	public function filter_activities( $activities ) {
+		return array_filter(
+			$activities,
+			function( $activity ) {
+				return \in_array( $activity->get_post()->post_type, Content_Helpers::get_post_types_names(), true );
+			}
+		);
+
 	}
 
 	/**
@@ -129,14 +147,13 @@ final class Published_Content_Density extends Widget {
 		// Get the all-time average.
 		static $density;
 		if ( null === $density ) {
-			$density = $this->count_density(
-				\progress_planner()->get_query()->query_activities(
-					[
-						'category' => 'content',
-						'type'     => 'publish',
-					]
-				)
-			);
+			$activities = $this->filter_activities( \progress_planner()->get_query()->query_activities(
+				[
+					'category' => 'content',
+					'type'     => 'publish',
+				]
+			) );
+			$density = $this->count_density( $activities );
 		}
 		return $density;
 	}

--- a/classes/widgets/class-published-content-density.php
+++ b/classes/widgets/class-published-content-density.php
@@ -95,11 +95,10 @@ final class Published_Content_Density extends Widget {
 	public function filter_activities( $activities ) {
 		return array_filter(
 			$activities,
-			function( $activity ) {
+			function ( $activity ) {
 				return \in_array( $activity->get_post()->post_type, Content_Helpers::get_post_types_names(), true );
 			}
 		);
-
 	}
 
 	/**
@@ -147,13 +146,15 @@ final class Published_Content_Density extends Widget {
 		// Get the all-time average.
 		static $density;
 		if ( null === $density ) {
-			$activities = $this->filter_activities( \progress_planner()->get_query()->query_activities(
-				[
-					'category' => 'content',
-					'type'     => 'publish',
-				]
-			) );
-			$density = $this->count_density( $activities );
+			$activities = $this->filter_activities(
+				\progress_planner()->get_query()->query_activities(
+					[
+						'category' => 'content',
+						'type'     => 'publish',
+					]
+				)
+			);
+			$density    = $this->count_density( $activities );
 		}
 		return $density;
 	}

--- a/classes/widgets/class-published-content.php
+++ b/classes/widgets/class-published-content.php
@@ -143,6 +143,24 @@ final class Published_Content extends Widget {
 				'type' => 'line',
 			],
 			'compound'     => false,
+			'filter_results' => [ $this, 'filter_activities' ],
 		];
+	}
+
+	/**
+	 * Callback to filter the activities.
+	 *
+	 * @param \Progress_Planner\Activities\Content[] $activities The activities array.
+	 *
+	 * @return \Progress_Planner\Activities\Content[]
+	 */
+	public function filter_activities( $activities ) {
+		return array_filter(
+			$activities,
+			function( $activity ) {
+				return \in_array( $activity->get_post()->post_type, Content_Helpers::get_post_types_names(), true );
+			}
+		);
+
 	}
 }

--- a/classes/widgets/class-published-content.php
+++ b/classes/widgets/class-published-content.php
@@ -129,20 +129,20 @@ final class Published_Content extends Widget {
 	 */
 	public function get_chart_args() {
 		return [
-			'query_params' => [
+			'query_params'   => [
 				'category' => 'content',
 				'type'     => 'publish',
 			],
-			'dates_params' => [
+			'dates_params'   => [
 				'start'     => \DateTime::createFromFormat( 'Y-m-d', \gmdate( 'Y-m-01' ) )->modify( $this->get_range() ),
 				'end'       => new \DateTime(),
 				'frequency' => $this->get_frequency(),
 				'format'    => 'M',
 			],
-			'chart_params' => [
+			'chart_params'   => [
 				'type' => 'line',
 			],
-			'compound'     => false,
+			'compound'       => false,
 			'filter_results' => [ $this, 'filter_activities' ],
 		];
 	}
@@ -157,10 +157,9 @@ final class Published_Content extends Widget {
 	public function filter_activities( $activities ) {
 		return array_filter(
 			$activities,
-			function( $activity ) {
+			function ( $activity ) {
 				return \in_array( $activity->get_post()->post_type, Content_Helpers::get_post_types_names(), true );
 			}
 		);
-
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -78,6 +78,12 @@ https://youtu.be/e1bmxZYyXFY
 
 == Upgrade Notice ==
 
+= 0.9.5 =
+
+Fixed:
+
+* Post-type filters intruduced in v0.9.4 now also affect the graph results.
+
 = 0.9.4 =
 
 Enhancements:

--- a/readme.txt
+++ b/readme.txt
@@ -78,7 +78,7 @@ https://youtu.be/e1bmxZYyXFY
 
 == Upgrade Notice ==
 
-= 0.9.5 =
+= - in development =
 
 Fixed:
 


### PR DESCRIPTION
## Context

The recently introduced settings for post-types were not affecting the graphs.

This PR adds a filter to allow filtering graphs based on the selected post-types.

IMPORTANT NOTE:
I thought of doing the same for badges, but I think we should leave those as-is... Badges is something that users have already earned and we should not have them un-earn a badge.