### PR TITLE
Use `wp.ajax.post`

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,4 +1,4 @@
-/* global progressPlannerAjaxRequest, progressPlanner */
+/* global progressPlanner */
 document
 	.getElementById( 'prpl-settings-form' )
 	.addEventListener( 'submit', function ( event ) {
@@ -7,16 +7,12 @@ document
 		const data = form.getAll( 'prpl-settings-post-types-include[]' );
 
 		// Save the options.
-		progressPlannerAjaxRequest( {
-			url: progressPlanner.ajaxUrl,
-			data: {
-				action: 'progress_planner_save_cpt_settings',
-				_ajax_nonce: progressPlanner.nonce,
-				include_post_types: data,
-			},
-			successAction: () => {
-				window.location.reload();
-			},
+		const request = wp.ajax.post( 'progress_planner_save_cpt_settings', {
+			_ajax_nonce: progressPlanner.nonce,
+			include_post_types: data,
+		} );
+		request.done( () => {
+			window.location.reload();
 		} );
 
 		document.getElementById( 'submit-include-post-types' ).disabled = true;

--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -34,8 +34,7 @@ jQuery( document ).ready( function () {
 		}
 
 		// Save the todo list to the database
-		jQuery.post( progressPlannerTodo.ajaxUrl, {
-			action: 'progress_planner_save_todo_list',
+		wp.ajax.post( 'progress_planner_save_todo_list', {
 			todo_list: todoList,
 			nonce: progressPlannerTodo.nonce,
 		} );


### PR DESCRIPTION
## Context
This PR aims to simplify some AJAX requests by using `wp.ajax.post` which is available in the admin.
It changes the implementation for the following:
* TODO tasks
* Settings popover

I did not change the implementation for the onboarding, as that is more complicated and needs a lot more testing.

## Summary

This PR can be summarized in the following changelog entry:

* Simplify JS scripts

## Test instructions
* Try adding/deleting/marking as done a couple of TODO items, then refresh the page to ensure changes have been saved
* Go to the post-type settings (the cog icon next to the date-range selectors in the header), make a change and save. The page should automatically refresh, and the post-type changes saved.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
