### PR TITLE
Refactor the todo script

### DIFF
--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -1,121 +1,146 @@
 /* global progressPlannerTodo, jQuery */
 
-jQuery( document ).ready( function () {
+/**
+ * Run a function when the DOM is ready.
+ * Similar to jQuery's $( document ).ready() - which has been deprecated.
+ *
+ * @param {Function} fn The function to run when the DOM is ready.
+ */
+const progressPlannerDomReady = ( fn ) => {
+	if ( document.readyState !== 'loading' ) {
+		fn();
+	} else {
+		document.addEventListener( 'DOMContentLoaded', fn );
+	}
+};
+
+/**
+ * Save the todo list to the database.
+ */
+const progressPlannerSaveTodoList = () => {
+	let todoList = [];
+
+	jQuery( '#todo-list li' ).each( function () {
+		const content = jQuery( this ).find( '.content' ).text();
+
+		todoList.push( {
+			content,
+			done: jQuery( this )
+				.find( 'input[type="checkbox"]' )
+				.prop( 'checked' ),
+		} );
+
+		// Update aria-labels
+		jQuery( this )
+			.find( 'input[type="checkbox"]' )
+			.attr( 'aria-label', content );
+		jQuery( this )
+			.find( '.trash' )
+			.attr(
+				'aria-label',
+				progressPlannerTodo.i18n.taskDelete.replace( '%s', content )
+			);
+	} );
+
+	if ( todoList.length === 0 ) {
+		todoList = 'empty';
+	}
+
+	// Save the todo list to the database
+	wp.ajax.post( 'progress_planner_save_todo_list', {
+		todo_list: todoList,
+		nonce: progressPlannerTodo.nonce,
+	} );
+};
+
+/**
+ * Initialize the sortable functionality for the todo list.
+ */
+const progressPlannerInitSortable = () => {
+	jQuery( '#todo-list' ).sortable( {
+		axis: 'y',
+		handle: '.prpl-todo-drag-handle',
+		update() {
+			// Add a 'data-order' attribute to each todo item
+			// based on its position in the list
+			jQuery( '#todo-list li' ).each( function ( index ) {
+				jQuery( this ).attr( 'data-order', index );
+			} );
+		},
+		stop: () => {
+			progressPlannerSaveTodoList();
+		},
+	} );
+};
+
+/**
+ * Inject a todo item into the DOM.
+ *
+ * @param {string}  content    The content of the todo item.
+ * @param {boolean} done       Whether the todo item is done.
+ * @param {boolean} addToStart Whether to add the todo item to the start of the list.
+ * @param {boolean} save       Whether to save the todo list to the database.
+ */
+const progressPlannerInjectTodoItem = ( content, done, addToStart, save ) => {
+	content = content
+		.trim()
+		.replace( /</g, '&lt;' )
+		.replace( />/g, '&gt;' )
+		.replace( '"', '&quot;' );
+
+	const deleteTaskAriaLabel = progressPlannerTodo.i18n.taskDelete.replace(
+		'%s',
+		content
+	);
+
+	const todoItemElement = jQuery( '<li></li>' ).html( `
+		<span class="prpl-todo-drag-handle" aria-label="${
+			progressPlannerTodo.i18n.drag
+		}">
+			<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+				<path d="M8 7h2V5H8v2zm0 6h2v-2H8v2zm0 6h2v-2H8v2zm6-14v2h2V5h-2zm0 8h2v-2h-2v2zm0 6h2v-2h-2v2z"></path>
+			</svg>
+		</span>
+		<input type="checkbox" aria-label="'${ content }'" ${ done ? 'checked' : '' }>
+		<span class="content" contenteditable="plaintext-only">${ content }</span>
+		<button class="trash" aria-label="${ deleteTaskAriaLabel }"><span class="dashicons dashicons-trash"></span></button>
+	` );
+
+	if ( addToStart ) {
+		jQuery( '#todo-list' ).prepend( todoItemElement );
+	} else {
+		jQuery( '#todo-list' ).append( todoItemElement );
+	}
+
+	// Focus the new task's content element after it is added to the DOM
+	setTimeout( () => {
+		todoItemElement.find( 'input[type="checkbox"]' ).focus();
+	}, 0 );
+
+	if ( save ) {
+		progressPlannerSaveTodoList();
+	}
+};
+
+progressPlannerDomReady( () => {
 	const announce = ( message ) => {
 		jQuery( '#todo-aria-live-region' ).text( message );
-	};
-	const saveTodoList = () => {
-		let todoList = [];
-
-		jQuery( '#todo-list li' ).each( function () {
-			const content = jQuery( this ).find( '.content' ).text();
-
-			todoList.push( {
-				content,
-				done: jQuery( this )
-					.find( 'input[type="checkbox"]' )
-					.prop( 'checked' ),
-			} );
-
-			// Update aria-labels
-			jQuery( this )
-				.find( 'input[type="checkbox"]' )
-				.attr( 'aria-label', content );
-			jQuery( this )
-				.find( '.trash' )
-				.attr(
-					'aria-label',
-					progressPlannerTodo.i18n.taskDelete.replace( '%s', content )
-				);
-		} );
-
-		if ( todoList.length === 0 ) {
-			todoList = 'empty';
-		}
-
-		// Save the todo list to the database
-		wp.ajax.post( 'progress_planner_save_todo_list', {
-			todo_list: todoList,
-			nonce: progressPlannerTodo.nonce,
-		} );
-	};
-
-	// Initialize the sortable.
-	const initSortable = () => {
-		jQuery( '#todo-list' ).sortable( {
-			axis: 'y',
-			handle: '.prpl-todo-drag-handle',
-			update() {
-				// Add a 'data-order' attribute to each todo item
-				// based on its position in the list
-				jQuery( '#todo-list li' ).each( function ( index ) {
-					jQuery( this ).attr( 'data-order', index );
-				} );
-			},
-			stop: () => {
-				saveTodoList();
-			},
-		} );
-	};
-
-	/**
-	 * Inject a todo item into the DOM.
-	 *
-	 * @param {string}  content    The content of the todo item.
-	 * @param {boolean} done       Whether the todo item is done.
-	 * @param {boolean} addToStart Whether to add the todo item to the start of the list.
-	 * @param {boolean} save       Whether to save the todo list to the database.
-	 */
-	const injectTodoItem = ( content, done, addToStart, save ) => {
-		content = content
-			.trim()
-			.replace( /</g, '&lt;' )
-			.replace( />/g, '&gt;' )
-			.replace( '"', '&quot;' );
-
-		const deleteTaskAriaLabel = progressPlannerTodo.i18n.taskDelete.replace(
-			'%s',
-			content
-		);
-
-		const todoItemElement = jQuery( '<li></li>' ).html( `
-			<span class="prpl-todo-drag-handle" aria-label="${
-				progressPlannerTodo.i18n.drag
-			}">
-				<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-					<path d="M8 7h2V5H8v2zm0 6h2v-2H8v2zm0 6h2v-2H8v2zm6-14v2h2V5h-2zm0 8h2v-2h-2v2zm0 6h2v-2h-2v2z"></path>
-				</svg>
-			</span>
-			<input type="checkbox" aria-label="'${ content }'" ${ done ? 'checked' : '' }>
-			<span class="content" contenteditable="plaintext-only">${ content }</span>
-			<button class="trash" aria-label="${ deleteTaskAriaLabel }"><span class="dashicons dashicons-trash"></span></button>
-		` );
-
-		if ( addToStart ) {
-			jQuery( '#todo-list' ).prepend( todoItemElement );
-		} else {
-			jQuery( '#todo-list' ).append( todoItemElement );
-		}
-
-		// Focus the new task's content element after it is added to the DOM
-		setTimeout( () => {
-			todoItemElement.find( 'input[type="checkbox"]' ).focus();
-		}, 0 );
-
-		if ( save ) {
-			saveTodoList();
-		}
 	};
 
 	// Inject the existing todo list items into the DOM
 	progressPlannerTodo.listItems.forEach( ( todoItem, index, array ) => {
 		jQuery( '#todo-list' ).append(
-			injectTodoItem( todoItem.content, todoItem.done, false, false )
+			progressPlannerInjectTodoItem(
+				todoItem.content,
+				todoItem.done,
+				false,
+				false
+			)
 		);
 
 		// If this is the last item in the array, initialize the sortable
 		if ( index === array.length - 1 ) {
-			initSortable();
+			progressPlannerInitSortable();
 		}
 	} );
 
@@ -123,7 +148,7 @@ jQuery( document ).ready( function () {
 	// add a new todo item to the list
 	jQuery( '#create-todo-item' ).submit( function ( event ) {
 		event.preventDefault();
-		injectTodoItem(
+		progressPlannerInjectTodoItem(
 			jQuery( '#new-todo-content' ).val(),
 			false, // Not done.
 			true, // Add to start.
@@ -141,7 +166,7 @@ jQuery( document ).ready( function () {
 		const todoItemDone = jQuery( this ).prop( 'checked' );
 
 		todoItem.remove();
-		injectTodoItem(
+		progressPlannerInjectTodoItem(
 			todoItemContent,
 			todoItemDone,
 			! todoItemDone,
@@ -164,7 +189,7 @@ jQuery( document ).ready( function () {
 	// When an item's contenteditable element is edited,
 	// save the new content to the database
 	jQuery( '#todo-list' ).on( 'input', '.content', function () {
-		saveTodoList();
+		progressPlannerSaveTodoList();
 	} );
 
 	// When the trash button is clicked, remove the todo item from the list
@@ -174,7 +199,7 @@ jQuery( document ).ready( function () {
 		const prevItem = todoItem.prev( 'li' );
 
 		todoItem.remove();
-		saveTodoList();
+		progressPlannerSaveTodoList();
 
 		// Shift focus to the next item if available, otherwise to the previous item, otherwise to the input field
 		if ( nextItem.length ) {

--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -150,7 +150,6 @@ progressPlannerDomReady( () => {
 		.getElementById( 'create-todo-item' )
 		.addEventListener( 'submit', ( event ) => {
 			event.preventDefault();
-			console.log(  );
 			progressPlannerInjectTodoItem(
 				document.getElementById( 'new-todo-content' ).value,
 				false, // Not done.

--- a/assets/js/todo.js
+++ b/assets/js/todo.js
@@ -146,17 +146,20 @@ progressPlannerDomReady( () => {
 
 	// When the '#create-todo-item' form is submitted,
 	// add a new todo item to the list
-	jQuery( '#create-todo-item' ).submit( function ( event ) {
-		event.preventDefault();
-		progressPlannerInjectTodoItem(
-			jQuery( '#new-todo-content' ).val(),
-			false, // Not done.
-			true, // Add to start.
-			true // Save.
-		);
+	document
+		.getElementById( 'create-todo-item' )
+		.addEventListener( 'submit', ( event ) => {
+			event.preventDefault();
+			console.log(  );
+			progressPlannerInjectTodoItem(
+				document.getElementById( 'new-todo-content' ).value,
+				false, // Not done.
+				true, // Add to start.
+				true // Save.
+			);
 
-		jQuery( '#new-todo-content' ).val( '' );
-	} );
+			document.getElementById( 'new-todo-content' ).value = '';
+		} );
 
 	// When an item is marked as done, move it to the end of the list.
 	// When an item is marked as not done, move it to the start of the list.

--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -194,7 +194,7 @@ class Page {
 		\wp_register_script(
 			'progress-planner-settings',
 			PROGRESS_PLANNER_URL . '/assets/js/settings.js',
-			[ 'progress-planner-ajax' ],
+			[ 'progress-planner-ajax', 'wp-util' ],
 			filemtime( PROGRESS_PLANNER_DIR . '/assets/js/settings.js' ),
 			true
 		);
@@ -211,7 +211,7 @@ class Page {
 		\wp_register_script(
 			'progress-planner-todo',
 			PROGRESS_PLANNER_URL . '/assets/js/todo.js',
-			[ 'jquery-ui-sortable', 'progress-planner-ajax' ],
+			[ 'jquery-ui-sortable', 'progress-planner-ajax', 'wp-util' ],
 			filemtime( PROGRESS_PLANNER_DIR . '/assets/js/todo.js' ),
 			true
 		);


### PR DESCRIPTION
## Context
The purpose of this PR is to allow future extensions to the todo functionality.

We used to have all functions wrapped inside a `jQuery( document ).ready()` call. 
This PR refactors a bit the todo script by pulling the defined functions _outside_ that call so they are available in other scripts we will have in the future, extending & augmenting the todo functionality.

Another minor tweak was to replace the `jQuery.ready` call with a vanilla JS implementation (`progressPlannerDomReady`) because I started getting some warnings in my IDE that `jQuery.ready` is getting deprecated.

## Summary

This PR can be summarized in the following changelog entry:

* Minor refactoring in the `todo` script

## Test instructions
* Test that todo items can still be marked as done, deleted, added and reordered. If these work, then there's no issue.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
