### PR TITLE
Add a db-version option and implement methods to upgrade the database

### DIFF
--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -472,10 +472,10 @@ class Query {
 		\sort( $available_upgrades );
 
 		// Run the upgrades.
-		foreach ( $available_upgrades as $upgrade ) {
-			$version = (int) \str_replace( 'upgrade_', '', $upgrade );
+		foreach ( $available_upgrades as $upgrade_method ) {
+			$version = (int) \str_replace( 'upgrade_', '', $upgrade_method );
 			if ( $version > $db_version ) {
-				$this->$upgrade();
+				$this->$upgrade_method();
 				$upgraded = $version;
 			}
 		}


### PR DESCRIPTION
## Context
Future-proofing:
* Added a `progress_planner_db_version` option
* Added a `Query::maybe_upgrade` method to run updates
* Added an upgrade routine for the `data_id` column

## Relevant technical choices:

* Routines for upgrade methods are named `upgrade_{DATE}`, where `DATE` is a numeric value year-month-day (example: `20241011` if the upgrade routine was written in October 11, 2024). This way we can ensure all upgrades run sequentially without getting too involved in finding version numbers for the db-upgrades etc.

Fixes #80 