### PR TITLE
Fix PHP warning when plugin is activated using WP CLI

### DIFF
--- a/classes/class-onboard.php
+++ b/classes/class-onboard.php
@@ -53,8 +53,10 @@ class Onboard {
 			return;
 		}
 
-		\wp_safe_redirect( \admin_url( 'admin.php?page=progress-planner' ) );
-		exit;
+		if ( ! \defined( 'WP_CLI' ) || ! \WP_CLI ) {
+			\wp_safe_redirect( \admin_url( 'admin.php?page=progress-planner' ) );
+			exit;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Context
When plugin is activated using WP CLI following PHP warning is triggered:

```
Warning: Some code is trying to do a URL redirect. Backtrace:
#0 ****/wp-includes/class-wp-hook.php(326): WP_CLI\Utils\wp_redirect_handler('http://planner....')
#1 ****/wp-includes/plugin.php(205): WP_Hook->apply_filters('http://planner....', Array)
#2 ****/wp-includes/pluggable.php(1396): apply_filters('wp_redirect', 'http://planner....', 302)
#3 ****/wp-includes/pluggable.php(1545): wp_redirect('http://planner....', 302, 'WordPress')
#4 ****/wp-content/plugins/progress-planner/classes/class-onboard.php(56): wp_safe_redirect('http://planner....')
#5 ****/wp-includes/class-wp-hook.php(326): Progress_Planner\Onboard->on_activate_plugin('progress-planne...')
#6 ****/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#7 ****/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#8 ****/wp-admin/includes/plugin.php(730): do_action('activated_plugi...', 'progress-planne...', false)
#9 phar:///usr/local/bin/wp/vendor/wp-cli/extension-command/src/Plugin_Command.php(363): activate_plugin('progress-planne...', '', false)
#10 [internal function]: Plugin_Command->activate(Array, Array)
#11 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(100): call_user_func(Array, Array, Array)
#12 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array, Array)
#13 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(497): call_user_func(Object(Closure), Array, Array)
#14 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(441): WP_CLI\Dispatcher\Subcommand->invoke(Array, Array, Array)
#15 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(464): WP_CLI\Runner->run_command(Array, Array)
#16 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1295): WP_CLI\Runner->run_command_and_exit()
#17 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#18 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(83): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#19 phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(32): WP_CLI\bootstrap()
#20 phar:///usr/local/bin/wp/php/boot-phar.php(20): include('phar:///usr/loc...')
#21 /usr/local/bin/wp(4): include('phar:///usr/loc...')
```

## Summary

This PR can be summarized in the following changelog entry:

Fix PHP warning when plugin is activated using WP CLI


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
