### PR TITLE
Make the word-count method properly count words for all languages

### DIFF
--- a/classes/activities/class-content-helpers.php
+++ b/classes/activities/class-content-helpers.php
@@ -60,9 +60,18 @@ class Content_Helpers {
 				true
 			);
 
-			$count = ( 'words' === $word_count_type )
-				? \str_word_count( $content )
-				: \strlen( $content );
+			switch ( $word_count_type ) {
+				case 'characters_excluding_spaces':
+					$content = \preg_replace( '/\s+/', '', $content );
+					// Fall through.
+
+				case 'characters_including_spaces':
+					$count = \strlen( $content );
+					break;
+
+				default:
+					$count = \str_word_count( $content );
+			}
 		}
 
 		if ( $post_id && \is_int( $post_id ) ) {

--- a/classes/activities/class-content-helpers.php
+++ b/classes/activities/class-content-helpers.php
@@ -49,13 +49,21 @@ class Content_Helpers {
 			return $counts[ $post_id ];
 		}
 
-		// Parse blocks and shortcodes.
-		$content = \do_blocks( \do_shortcode( $content ) );
+		$word_count_type = function_exists( 'wp_get_word_count_type' ) ? wp_get_word_count_type() : 'words';
+		if ( function_exists( 'wp_word_count' ) ) {
+			$count = wp_word_count( $content, $word_count_type );
+		} else {
+			$content = \wp_strip_all_tags( // Strip HTML.
+				\do_blocks( // Parse blocks.
+					\do_shortcode( $content ) // Parse shortcodes.
+				),
+				true
+			);
 
-		// Strip HTML.
-		$content = \wp_strip_all_tags( $content, true );
-
-		$count = \str_word_count( $content );
+			$count = ( 'words' === $word_count_type )
+				? \str_word_count( $content )
+				: \strlen( $content );
+		}
 
 		if ( $post_id && \is_int( $post_id ) ) {
 			Settings::set( [ 'word_count', $post_id ], $count );


### PR DESCRIPTION
This PR implements a way to determine how words should be counted.

Uses the [`wp_get_word_count_type`](https://developer.wordpress.org/reference/functions/wp_get_word_count_type/) function to get the count-type for the current locale. If the `wp_get_word_count_type` function doesn't exist, then we fallback to counting `words`.

There's a [PR in WP-Core](https://github.com/WordPress/wordpress-develop/pull/4430) to introduce a `wp_word_count` function. If that function exists, we use it in order to future-proof the implementation, otherwise we count words/characters depending on the locale.

Fixes #86 
