### PR TITLE
User can register from Settings popover

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1156,6 +1156,7 @@ button.prpl-info-icon {
 /*------------------------------------*\
 	Settings popup.
 \*------------------------------------*/
+#prpl-settings-license-form,
 #prpl-settings-form {
 
 	label {
@@ -1189,5 +1190,15 @@ button.prpl-info-icon {
 
 	button:hover {
 		background-color: var(--prpl-background-orange);
+	}
+}
+
+#prpl-settings-license-form {
+
+	label {
+		display: grid;
+		grid-template-columns: 1fr 3fr;
+		margin-bottom: 0.5em;
+		gap: var(--prpl-padding);
 	}
 }

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,4 +1,4 @@
-/* global progressPlanner */
+/* global progressPlanner, progressPlannerAjaxRequest, progressPlannerSaveLicenseKey */
 document
 	.getElementById( 'prpl-settings-form' )
 	.addEventListener( 'submit', function ( event ) {
@@ -19,3 +19,55 @@ document
 		document.getElementById( 'submit-include-post-types' ).innerHTML =
 			progressPlanner.l10n.saving;
 	} );
+
+// Submit the email.
+const settingsLicenseForm = document.getElementById(
+	'prpl-settings-license-form'
+);
+if ( !! settingsLicenseForm ) {
+	settingsLicenseForm.addEventListener( 'submit', function ( event ) {
+		event.preventDefault();
+		const form = new FormData( this );
+		const data = {};
+
+		// Build the onboarding data object.
+		for ( const [ key, value ] of form.entries() ) {
+			data[ key ] = value;
+		}
+
+		progressPlannerAjaxRequest( {
+			url: progressPlanner.onboardNonceURL,
+			data,
+			successAction: ( response ) => {
+				if ( 'ok' === response.status ) {
+					// Add the nonce to our data object.
+					data.nonce = response.nonce;
+
+					// Make the request to the API.
+					progressPlannerAjaxRequest( {
+						url: progressPlanner.onboardAPIUrl,
+						data,
+						successAction: ( apiResponse ) => {
+							// Make a local request to save the response data.
+							progressPlannerSaveLicenseKey(
+								apiResponse.license_key
+							);
+
+							document.getElementById(
+								'submit-license-key'
+							).innerHTML = progressPlanner.l10n.subscribed;
+						},
+						failAction: ( apiResponse ) => {
+							// eslint-disable-next-line no-console
+							console.warn( apiResponse );
+						},
+					} );
+				}
+			},
+		} );
+
+		document.getElementById( 'submit-license-key' ).disabled = true;
+		document.getElementById( 'submit-license-key' ).innerHTML =
+			progressPlanner.l10n.subscribing;
+	} );
+}

--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -230,7 +230,9 @@ class Page {
 			$localize_data,
 			[
 				'l10n' => [
-					'saving' => \esc_html__( 'Saving...', 'progress-planner' ),
+					'saving'      => \esc_html__( 'Saving...', 'progress-planner' ),
+					'subscribing' => \esc_html__( 'Subscribing...', 'progress-planner' ),
+					'subscribed'  => \esc_html__( 'Subscribed...', 'progress-planner' ),
 				],
 			]
 		);

--- a/classes/class-onboard.php
+++ b/classes/class-onboard.php
@@ -30,15 +30,16 @@ class Onboard {
 	 * Constructor.
 	 */
 	public function __construct() {
+
+		// Handle saving data from the onboarding form response.
+		\add_action( 'wp_ajax_progress_planner_save_onboard_data', [ $this, 'save_onboard_response' ] );
+
 		if ( \get_option( 'progress_planner_license_key' ) ) {
 			return;
 		}
 
 		// Redirect on plugin activation.
 		\add_action( 'activated_plugin', [ $this, 'on_activate_plugin' ], 10 );
-
-		// Handle saving data from the onboarding form response.
-		\add_action( 'wp_ajax_progress_planner_save_onboard_data', [ $this, 'save_onboard_response' ] );
 	}
 
 	/**
@@ -177,6 +178,7 @@ class Onboard {
 
 		$license_key = \sanitize_text_field( wp_unslash( $_POST['key'] ) );
 
+		// False also if option value has not changed.
 		if ( \update_option( 'progress_planner_license_key', $license_key, false ) ) {
 			\wp_send_json_success(
 				[

--- a/classes/popups/class-settings.php
+++ b/classes/popups/class-settings.php
@@ -69,6 +69,67 @@ final class Settings extends Popup {
 
 			<button id="submit-include-post-types" class="button button-primary"><?php \esc_html_e( 'Save', 'progress-planner' ); ?></button>
 		</form>
+
+		<?php
+		$saved_license_key = \get_option( 'progress_planner_license_key', 'no-license' );
+
+		if ( false === $saved_license_key || 'no-license' === $saved_license_key ) :
+			?>
+		<form id="prpl-settings-license-form">
+
+			<?php
+			$current_user = \wp_get_current_user();
+			?>
+			<h3><?php \esc_html_e( 'Subscribe to weekly emails', 'progress-planner' ); ?></h3>
+			<p>
+			<?php
+			printf(
+				/* translators: %s: progressplanner.com link */
+				\esc_html__( 'We can send you weekly emails with your own to-do’s, your activity stats and nudges to keep you working on your site. To do this, we’ll create an account for you on %s.', 'progress-planner' ),
+				'<a href="https://prpl.fyi/home" target="_blank">progressplanner.com</a>'
+			)
+			?>
+			</p>
+			<div class="prpl-form-fields">
+				<label>
+					<span class="prpl-label-content">
+						<?php \esc_html_e( 'First name', 'progress-planner' ); ?>
+					</span>
+					<input
+						type="text"
+						name="name"
+						class="prpl-input"
+						required
+						value="<?php echo \esc_attr( \get_user_meta( $current_user->ID, 'first_name', true ) ); ?>"
+					>
+				</label>
+				<label>
+					<span class="prpl-label-content">
+						<?php \esc_html_e( 'Email', 'progress-planner' ); ?>
+					</span>
+					<input
+						type="email"
+						name="email"
+						class="prpl-input"
+						required
+						value="<?php echo \esc_attr( $current_user->user_email ); ?>"
+					>
+				</label>
+				<input
+					type="hidden"
+					name="site"
+					value="<?php echo \esc_attr( \set_url_scheme( \site_url() ) ); ?>"
+				>
+				<input
+					type="hidden"
+					name="timezone_offset"
+					value="<?php echo (float) ( \wp_timezone()->getOffset( new \DateTime( 'midnight' ) ) / 3600 ); ?>"
+				>
+			</div>
+			<button id="submit-license-key" class="button button-primary"><?php \esc_html_e( 'Subscribe', 'progress-planner' ); ?></button>
+		</form>
+		<?php endif; ?>
+
 		<?php
 	}
 }


### PR DESCRIPTION
## Context
Currently user can't register after he / she closes the Onboard popover, we are adding Register form to the Setttings popover to allow them to do so.

## Summary

This PR can be summarized in the following changelog entry:

Add Register form to the Settings popover.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes https://github.com/Emilia-Capital/progress-planner/issues/89