### PR TITLE
Post types are not saved (Settings Popover)

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -9,7 +9,7 @@ document
 		// Save the options.
 		const request = wp.ajax.post( 'progress_planner_save_cpt_settings', {
 			_ajax_nonce: progressPlanner.nonce,
-			include_post_types: data,
+			include_post_types: data.join( ',' ),
 		} );
 		request.done( () => {
 			window.location.reload();


### PR DESCRIPTION
## Context

Selected Post Types, in the Settings popover, are not saved in our settings. Reason being is that we send an array [here](https://github.com/Emilia-Capital/progress-planner/blob/3b77db1d91c34127585e81915334f5a526cdf97a/assets/js/settings.js#L12), but when sanitizing before save sanitize_text_field makes an empty string out of it [here](https://github.com/Emilia-Capital/progress-planner/blob/3b77db1d91c34127585e81915334f5a526cdf97a/classes/admin/class-page.php#L256).

## Summary

This PR can be summarized in the following changelog entry:

Fix saving Post types from Settings popover

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes https://github.com/Emilia-Capital/progress-planner/issues/92
