### PR TITLE
Move subscribe form to its own popover

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -56,6 +56,9 @@ if ( !! settingsLicenseForm ) {
 							document.getElementById(
 								'submit-license-key'
 							).innerHTML = progressPlanner.l10n.subscribed;
+
+							// Reload the page.
+							window.location.reload();
 						},
 						failAction: ( apiResponse ) => {
 							// eslint-disable-next-line no-console

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -299,8 +299,9 @@ class Base {
 		if ( ! $this->popovers ) {
 			$this->popovers = new \stdClass();
 		}
-		$this->popovers->badges   = new \Progress_Planner\Popovers\Badges();
-		$this->popovers->settings = new \Progress_Planner\Popovers\Settings();
+		$this->popovers->badges         = new \Progress_Planner\Popovers\Badges();
+		$this->popovers->settings       = new \Progress_Planner\Popovers\Settings();
+		$this->popovers->subscribe_form = new \Progress_Planner\Popovers\Subscribe_Form();
 
 		return $this->popovers;
 	}

--- a/classes/popovers/class-settings.php
+++ b/classes/popovers/class-settings.php
@@ -67,67 +67,6 @@ final class Settings extends Popover {
 
 			<button id="submit-include-post-types" class="button button-primary"><?php \esc_html_e( 'Save', 'progress-planner' ); ?></button>
 		</form>
-
-		<?php
-		$saved_license_key = \get_option( 'progress_planner_license_key', 'no-license' );
-
-		if ( false === $saved_license_key || 'no-license' === $saved_license_key ) :
-			?>
-		<form id="prpl-settings-license-form">
-
-			<?php
-			$current_user = \wp_get_current_user();
-			?>
-			<h3><?php \esc_html_e( 'Subscribe to weekly emails', 'progress-planner' ); ?></h3>
-			<p>
-			<?php
-			printf(
-				/* translators: %s: progressplanner.com link */
-				\esc_html__( 'We can send you weekly emails with your own to-do’s, your activity stats and nudges to keep you working on your site. To do this, we’ll create an account for you on %s.', 'progress-planner' ),
-				'<a href="https://prpl.fyi/home" target="_blank">progressplanner.com</a>'
-			)
-			?>
-			</p>
-			<div class="prpl-form-fields">
-				<label>
-					<span class="prpl-label-content">
-						<?php \esc_html_e( 'First name', 'progress-planner' ); ?>
-					</span>
-					<input
-						type="text"
-						name="name"
-						class="prpl-input"
-						required
-						value="<?php echo \esc_attr( \get_user_meta( $current_user->ID, 'first_name', true ) ); ?>"
-					>
-				</label>
-				<label>
-					<span class="prpl-label-content">
-						<?php \esc_html_e( 'Email', 'progress-planner' ); ?>
-					</span>
-					<input
-						type="email"
-						name="email"
-						class="prpl-input"
-						required
-						value="<?php echo \esc_attr( $current_user->user_email ); ?>"
-					>
-				</label>
-				<input
-					type="hidden"
-					name="site"
-					value="<?php echo \esc_attr( \set_url_scheme( \site_url() ) ); ?>"
-				>
-				<input
-					type="hidden"
-					name="timezone_offset"
-					value="<?php echo (float) ( \wp_timezone()->getOffset( new \DateTime( 'midnight' ) ) / 3600 ); ?>"
-				>
-			</div>
-			<button id="submit-license-key" class="button button-primary"><?php \esc_html_e( 'Subscribe', 'progress-planner' ); ?></button>
-		</form>
-		<?php endif; ?>
-
 		<?php
 	}
 }

--- a/classes/popovers/class-subscribe-form.php
+++ b/classes/popovers/class-subscribe-form.php
@@ -27,15 +27,16 @@ final class Subscribe_Form extends Popover {
 	public function render_button() {
 
 		$saved_license_key = \get_option( 'progress_planner_license_key', 'no-license' );
-
-		if ( false === $saved_license_key || 'no-license' === $saved_license_key ) : ?>
+		if ( false !== $saved_license_key && 'no-license' !== $saved_license_key ) {
+			return;
+		}
+		?>
 		<!-- The triggering button. -->
 		<button class="prpl-info-icon" popovertarget="prpl-popover-<?php echo \esc_attr( $this->id ); ?>" id="prpl-popover-subscribe-form-trigger">
 			<span class="dashicons dashicons-email-alt"></span>
 			<span class="screen-reader-text"><?php \esc_html_e( 'Subscribe', 'progress-planner' ); ?>
 		</button>
-			<?php
-		endif;
+		<?php
 	}
 
 	/**

--- a/classes/popovers/class-subscribe-form.php
+++ b/classes/popovers/class-subscribe-form.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Subscribe form popup.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Popovers;
+
+/**
+ * Subscribe form popup.
+ */
+final class Subscribe_Form extends Popover {
+
+	/**
+	 * The popover ID.
+	 *
+	 * @var string
+	 */
+	protected $id = 'subscribe-form';
+
+	/**
+	 * Render the triggering button.
+	 *
+	 * @return void
+	 */
+	public function render_button() {
+
+		$saved_license_key = \get_option( 'progress_planner_license_key', 'no-license' );
+
+		if ( false === $saved_license_key || 'no-license' === $saved_license_key ) : ?>
+		<!-- The triggering button. -->
+		<button class="prpl-info-icon" popovertarget="prpl-popover-<?php echo \esc_attr( $this->id ); ?>" id="prpl-popover-subscribe-form-trigger">
+			<span class="dashicons dashicons-email-alt"></span>
+			<span class="screen-reader-text"><?php \esc_html_e( 'Subscribe', 'progress-planner' ); ?>
+		</button>
+			<?php
+		endif;
+	}
+
+	/**
+	 * Render the widget content.
+	 *
+	 * @return void
+	 */
+	protected function the_content() {
+		$current_user = \wp_get_current_user();
+		?>
+
+		<h2><?php \esc_html_e( 'Subscribe to weekly emails', 'progress-planner' ); ?></h2>
+
+		<form id="prpl-settings-license-form">
+
+			<p>
+			<?php
+			printf(
+				/* translators: %s: progressplanner.com link */
+				\esc_html__( 'We can send you weekly emails with your own to-do’s, your activity stats and nudges to keep you working on your site. To do this, we’ll create an account for you on %s.', 'progress-planner' ),
+				'<a href="https://prpl.fyi/home" target="_blank">progressplanner.com</a>'
+			)
+			?>
+			</p>
+			<div class="prpl-form-fields">
+				<label>
+					<span class="prpl-label-content">
+						<?php \esc_html_e( 'First name', 'progress-planner' ); ?>
+					</span>
+					<input
+						type="text"
+						name="name"
+						class="prpl-input"
+						required
+						value="<?php echo \esc_attr( \get_user_meta( $current_user->ID, 'first_name', true ) ); ?>"
+					>
+				</label>
+				<label>
+					<span class="prpl-label-content">
+						<?php \esc_html_e( 'Email', 'progress-planner' ); ?>
+					</span>
+					<input
+						type="email"
+						name="email"
+						class="prpl-input"
+						required
+						value="<?php echo \esc_attr( $current_user->user_email ); ?>"
+					>
+				</label>
+				<input
+					type="hidden"
+					name="site"
+					value="<?php echo \esc_attr( \set_url_scheme( \site_url() ) ); ?>"
+				>
+				<input
+					type="hidden"
+					name="timezone_offset"
+					value="<?php echo (float) ( \wp_timezone()->getOffset( new \DateTime( 'midnight' ) ) / 3600 ); ?>"
+				>
+			</div>
+			<button id="submit-license-key" class="button button-primary"><?php \esc_html_e( 'Subscribe', 'progress-planner' ); ?></button>
+		</form>
+
+		<?php
+	}
+}

--- a/views/admin-page-header.php
+++ b/views/admin-page-header.php
@@ -29,6 +29,8 @@ $progress_planner_active_frequency = isset( $_GET['frequency'] ) ? \sanitize_tex
 		</button>
 		<?php \progress_planner()->get_popovers()->settings->render_button(); ?>
 		<?php \progress_planner()->get_popovers()->settings->render(); ?>
+		<?php \progress_planner()->get_popovers()->subscribe_form->render_button(); ?>
+		<?php \progress_planner()->get_popovers()->subscribe_form->render(); ?>
 		<div class="prpl-header-select-range">
 			<label for="prpl-select-range" class="screen-reader-text">
 				<?php \esc_html_e( 'Select range:', 'progress-planner' ); ?>


### PR DESCRIPTION
## Context
Pull the subscribe form outside the settings popover
Create a new subscribe popover
Add an email icon next to the bulb/settings buttons to trigger the new popover

## Summary

This PR can be summarized in the following changelog entry:

Subscribe form is moved to its own popover.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

