### PR TITLE
Improve cache when fetching lessons

### DIFF
--- a/classes/class-lessons.php
+++ b/classes/class-lessons.php
@@ -53,7 +53,7 @@ class Lessons {
 			'https://progressplanner.com/wp-json/progress-planner-saas/v1/free-lessons'
 		);
 
-		$cache_key = 'lessons-' . $url;
+		$cache_key = 'lessons-' . md5( $url );
 
 		$cached = \progress_planner()->get_cache()->get( $cache_key );
 		if ( is_array( $cached ) ) {

--- a/classes/class-lessons.php
+++ b/classes/class-lessons.php
@@ -42,37 +42,45 @@ class Lessons {
 	 * @return array
 	 */
 	public function get_remote_api_items() {
-		$cached = \progress_planner()->get_cache()->get( 'lessons' );
-		if ( is_array( $cached ) && ! empty( $cached ) ) {
+
+		/**
+		 * Filter the endpoint url for the lessons.
+		 *
+		 * @param string $endpoint The endpoint url.
+		 */
+		$url = apply_filters(
+			'progress_planner_lessons_endpoint',
+			'https://progressplanner.com/wp-json/progress-planner-saas/v1/free-lessons'
+		);
+
+		$cache_key = 'lessons-' . $url;
+
+		$cached = \progress_planner()->get_cache()->get( $cache_key );
+		if ( is_array( $cached ) ) {
 			return $cached;
 		}
 
 		$response = \wp_remote_get(
-			/**
-			 * Filter the endpoint url for the lessons.
-			 *
-			 * @param string $endpoint The endpoint url.
-			 */
-			apply_filters(
-				'progress_planner_lessons_endpoint',
-				'https://progressplanner.com/wp-json/progress-planner-saas/v1/free-lessons'
-			)
+			$url
 		);
 
 		if ( \is_wp_error( $response ) ) {
+			\progress_planner()->get_cache()->set( $cache_key, [], 5 * MINUTE_IN_SECONDS );
 			return [];
 		}
 
 		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			\progress_planner()->get_cache()->set( $cache_key, [], 5 * MINUTE_IN_SECONDS );
 			return [];
 		}
 
 		$json = json_decode( \wp_remote_retrieve_body( $response ), true );
 		if ( ! is_array( $json ) ) {
+			\progress_planner()->get_cache()->set( $cache_key, [], 5 * MINUTE_IN_SECONDS );
 			return [];
 		}
 
-		\progress_planner()->get_cache()->set( 'lessons', $json, WEEK_IN_SECONDS );
+		\progress_planner()->get_cache()->set( $cache_key, $json, WEEK_IN_SECONDS );
 
 		return $json;
 	}


### PR DESCRIPTION
## Context
Due to the way how currently our code works fetching lessons from API is done on every `init` (I get it even on front end, not just in Dashboard).

If request is successful the response is cached, but if it is not our server will be hammered. To prevent that I cached empty array with 5 minutes lifetime in case that request fails.

Another problem is that `$url` can be filtered, but the cache key is never changed - meaning that even if $url is changed user will keep getting lessons which were fetched from old `$url` until the cache expires (which can be up to a week).

I used `$url` in order to make `$cache_key` unique and left it unchanged in order to make possible (future) debugging easier.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

