### PR TITLE
Fix confetti triggered for local tasks which were completed after snoozing

### DIFF
--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -312,6 +312,18 @@ class Suggested_Tasks {
 	}
 
 	/**
+	 * Get the completed tasks.
+	 *
+	 * @return array
+	 */
+	public function get_completed_tasks() {
+		$option    = \get_option( self::OPTION_NAME, [] );
+		$completed = $option['completed'] ?? [];
+
+		return $completed;
+	}
+
+	/**
 	 * Mark a task as snoozed.
 	 *
 	 * @param string $task_id The task ID.
@@ -367,6 +379,82 @@ class Suggested_Tasks {
 				$this->remove_task_from( 'snoozed', $task['id'] );
 			}
 		}
+	}
+
+	/**
+	 * Check if a task meets a condition.
+	 *
+	 * @param array $condition The condition.
+	 *                         [
+	 *                           string  'type'         The condition type.
+	 *                           string  'task_id'      The task id (optional, used for completed and snoozed conditions).
+	 *                           array   'post_lengths' The post lengths (optional, used for snoozed-post-length condition).
+	 *                         ].
+	 *
+	 * @return bool
+	 */
+	public function check_task_condition( $condition ) {
+
+		if ( ! \is_array( $condition ) ) {
+			$condition['type'] = $condition;
+		}
+
+		$parsed_condition = \wp_parse_args(
+			$condition,
+			[
+				'type'         => '',
+				'task_id'      => '',
+				'post_lengths' => [],
+			]
+		);
+
+		if ( 'completed' === $parsed_condition['type'] ) {
+			$completed_tasks = $this->get_completed_tasks();
+
+			if ( \in_array( $parsed_condition['task_id'], $completed_tasks, true ) ) {
+				return true;
+			}
+		}
+
+		if ( 'snoozed' === $parsed_condition['type'] ) {
+			$snoozed_tasks = $this->get_snoozed_tasks();
+
+			if ( \in_array( $parsed_condition['task_id'], $snoozed_tasks, true ) ) {
+				return true;
+			}
+		}
+
+		if ( 'snoozed-post-length' === $parsed_condition['type'] && isset( $parsed_condition['post_lengths'] ) ) {
+			if ( ! \is_array( $parsed_condition['post_lengths'] ) ) {
+				$parsed_condition['post_lengths'] = [ $parsed_condition['post_lengths'] ];
+			}
+
+			$snoozed_tasks        = $this->get_snoozed_tasks();
+			$snoozed_post_lengths = [];
+
+			// Get the post lengths of the snoozed tasks.
+			foreach ( $snoozed_tasks as $task ) {
+				$data = $this->local->get_data_from_task_id( $task['id'] );
+				if ( isset( $data['type'] ) && 'create-post' === $data['type'] ) {
+					$key = true === $data['long'] ? 'long' : 'short';
+					if ( ! isset( $snoozed_post_lengths[ $key ] ) ) {
+						$snoozed_post_lengths[ $key ] = true;
+					}
+				}
+			}
+
+			// Check if the snoozed post lengths match the condition.
+			foreach ( $parsed_condition['post_lengths'] as $post_length ) {
+				if ( ! isset( $snoozed_post_lengths[ $post_length ] ) ) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		// If no condition is met, return false.
+		return false;
 	}
 
 	/**

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -359,6 +359,9 @@ class Suggested_Tasks {
 				break;
 		}
 
+		// Remove the task from the pending local tasks list.
+		$this->local->remove_pending_task( $task_id );
+
 		return $this->mark_task_as_snoozed( $task_id, $time );
 	}
 

--- a/classes/suggested-tasks/local-tasks/class-update-content.php
+++ b/classes/suggested-tasks/local-tasks/class-update-content.php
@@ -166,7 +166,7 @@ class Update_Content extends \Progress_Planner\Suggested_Tasks\Local_Tasks {
 		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
 			[
 				'type'         => 'snoozed-post-length',
-				'post_lengths' => [ $is_last_post_long ? 'long' : 'short' ],
+				'post_lengths' => [ $is_last_post_long ? 'short' : 'long' ],
 			]
 		) ) {
 			return [];
@@ -180,7 +180,7 @@ class Update_Content extends \Progress_Planner\Suggested_Tasks\Local_Tasks {
 			]
 		);
 
-		// If the task with this length is completed, don't add a task.
+		// If the task with this length and id is completed, don't add a task.
 		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
 			[
 				'type'    => 'completed',

--- a/classes/suggested-tasks/local-tasks/class-update-content.php
+++ b/classes/suggested-tasks/local-tasks/class-update-content.php
@@ -135,12 +135,15 @@ class Update_Content extends \Progress_Planner\Suggested_Tasks\Local_Tasks {
 	 * @return array
 	 */
 	public function get_tasks_to_create_posts() {
-		$items                = [];
-		$snoozed_post_lengths = $this->get_snoozed_post_lengths();
 
-		// We have both long and short posts snoozed.
-		if ( ! empty( $snoozed_post_lengths ) && \in_array( 'long', $snoozed_post_lengths, true ) && \in_array( 'short', $snoozed_post_lengths, true ) ) {
-			return $items;
+		// Early exit if we have both long and short posts snoozed.
+		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
+			[
+				'type'         => 'snoozed-post-length',
+				'post_lengths' => [ 'long', 'short' ],
+			]
+		) ) {
+			return [];
 		}
 
 		// Get the post that was created last.
@@ -159,9 +162,14 @@ class Update_Content extends \Progress_Planner\Suggested_Tasks\Local_Tasks {
 			&& \progress_planner()->get_activities__content_helpers()->is_post_long( $last_created_posts[0]->ID )
 		);
 
-		// If the last post is snoozed, don't add a task.
-		if ( ! empty( $snoozed_post_lengths ) && \in_array( $is_last_post_long ? 'long' : 'short', $snoozed_post_lengths, true ) ) {
-			return $items;
+		// If the task with this length is snoozed, don't add a task.
+		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
+			[
+				'type'         => 'snoozed-post-length',
+				'post_lengths' => [ $is_last_post_long ? 'long' : 'short' ],
+			]
+		) ) {
+			return [];
 		}
 
 		$task_id = $this->get_task_id(
@@ -172,9 +180,17 @@ class Update_Content extends \Progress_Planner\Suggested_Tasks\Local_Tasks {
 			]
 		);
 
-		$items[] = $this->get_task_details( $task_id );
+		// If the task with this length is completed, don't add a task.
+		if ( true === \progress_planner()->get_suggested_tasks()->check_task_condition(
+			[
+				'type'    => 'completed',
+				'task_id' => $task_id,
+			]
+		) ) {
+			return [];
+		}
 
-		return $items;
+		return [ $this->get_task_details( $task_id ) ];
 	}
 
 	/**
@@ -309,27 +325,6 @@ class Update_Content extends \Progress_Planner\Suggested_Tasks\Local_Tasks {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Get the snoozed post lengths.
-	 *
-	 * @return array
-	 */
-	public function get_snoozed_post_lengths() {
-		$snoozed              = \progress_planner()->get_suggested_tasks()->get_snoozed_tasks();
-		$snoozed_post_lengths = [];
-
-		if ( \is_array( $snoozed ) && ! empty( $snoozed ) ) {
-			foreach ( $snoozed as $task ) {
-				$data = $this->get_data_from_task_id( $task['id'] );
-				if ( isset( $data['type'] ) && 'create-post' === $data['type'] ) {
-					$snoozed_post_lengths[] = true === $data['long'] ? 'long' : 'short';
-				}
-			}
-		}
-
-		return $snoozed_post_lengths;
 	}
 
 	/**


### PR DESCRIPTION
## Context

Fixes following case:

- user gets a local tasks and he snoozes it (snoozed is saved in `progress_planner_suggested_tasks`)
- but then later he completes the task (for example creates a short post)
- when PP page is visited confetti are fired (since local tasks are saved in `progress_planner_local_tasks`  )

Also I improved local tasks checks, for checking if task is completed, snoozed, celebrated and etc, to be more re-usable.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

