### PR TITLE
Resume welcome tour from the same step after page reload

### DIFF
--- a/assets/js/tour.js
+++ b/assets/js/tour.js
@@ -18,9 +18,49 @@ const prplDriverObj = prplDriver( {
 				scanFinishedNotice.remove();
 			}
 		}
+
+		// Remove tour_step from URL when tour is destroyed.
+		const newUrl = new URL( window.location );
+		newUrl.searchParams.delete( 'tour_step' );
+		window.history.replaceState( {}, '', newUrl );
+
 		prplDriverObj.destroy();
 	},
+	onPopoverRender: (
+		popover, // eslint-disable-line no-unused-vars
+		{ config, state } // eslint-disable-line no-unused-vars
+	) => {
+		const settingsPopover = document.getElementById(
+			'prpl-popover-settings'
+		);
+		const monthlyBadgesPopover = document.getElementById(
+			'prpl-popover-monthly-badges'
+		);
+
+		if ( state.activeIndex === 4 ) {
+			prplTourShowPopover( settingsPopover );
+		}
+
+		if ( state.activeIndex === 7 ) {
+			prplTourShowPopover( monthlyBadgesPopover );
+		}
+
+		// Update URL with current step.
+		const newUrl = new URL( window.location );
+		newUrl.searchParams.set( 'tour_step', state.activeIndex );
+		window.history.replaceState( {}, '', newUrl );
+	},
 } );
+
+function prplTourShowPopover( popover ) {
+	popover.showPopover();
+	prplMakePopoverBackdropTransparent( popover );
+}
+
+function prplTourHidePopover( popover ) {
+	popover.hidePopover();
+	document.getElementById( popover.id + '-backdrop-transparency' ).remove();
+}
 
 // Function to make the backdrop of a popover transparent.
 function prplMakePopoverBackdropTransparent( popover ) {
@@ -44,33 +84,34 @@ function prplStartTour() {
 	);
 	const progressPlannerTourSteps = progressPlannerTour.steps;
 	progressPlannerTourSteps[ 3 ].popover.onNextClick = function () {
-		settingsPopover.showPopover();
-		prplMakePopoverBackdropTransparent( settingsPopover );
+		prplTourShowPopover( settingsPopover );
 		prplDriverObj.moveNext();
 	};
 	progressPlannerTourSteps[ 4 ].popover.onNextClick = function () {
-		settingsPopover.hidePopover();
-		document
-			.getElementById( settingsPopover.id + '-backdrop-transparency' )
-			.remove();
+		prplTourHidePopover( settingsPopover );
 		prplDriverObj.moveNext();
 	};
 
 	progressPlannerTourSteps[ 6 ].popover.onNextClick = function () {
-		monthlyBadgesPopover.showPopover();
-		prplMakePopoverBackdropTransparent( monthlyBadgesPopover );
+		prplTourShowPopover( monthlyBadgesPopover );
 		prplDriverObj.moveNext();
 	};
 	progressPlannerTourSteps[ 7 ].popover.onNextClick = function () {
-		monthlyBadgesPopover.hidePopover();
-		document
-			.getElementById(
-				monthlyBadgesPopover.id + '-backdrop-transparency'
-			)
-			.remove();
+		prplTourHidePopover( monthlyBadgesPopover );
 		prplDriverObj.moveNext();
 	};
-	prplDriverObj.drive();
+
+	// Check URL parameters.
+	const urlParams = new URLSearchParams( window.location.search );
+	const savedStepIndex = urlParams.get( 'tour_step' );
+
+	if ( null !== savedStepIndex ) {
+		// Start from saved step.
+		prplDriverObj.drive( parseInt( savedStepIndex, 10 ) );
+	} else {
+		// Start from beginning.
+		prplDriverObj.drive( 0 );
+	}
 
 	// Remove `content-scan-finished=true` from the URL, without refreshing the page.
 	window.history.replaceState(


### PR DESCRIPTION
## Context
During the welcome tour if a user reloads the page, for example save Settings popup, the tour progress would reset - meaning that if user starts tour again it will start from 1st step.

This PR adds param in the URL which updates with tour progress, so in such cases it can be resumed from the exact step on which it was interrupted.

If the tour is finished or closed the URL param is removed - so the next tour starts again from the 1st step.

## Summary

This PR can be summarized in the following changelog entry:

Resume welcome tour from the same step after page reload

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes [#](https://github.com/Emilia-Capital/progress-planner/issues/97)
