### PR TITLE
Dont display dashboard widgets for authors

### DIFF
--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -44,7 +44,7 @@ class Base {
 		}
 
 		// Basic classes.
-		if ( \is_admin() && \current_user_can( 'publish_posts' ) ) {
+		if ( \is_admin() && \current_user_can( 'edit_others_posts' ) ) {
 			$this->cached['admin__page']                   = new \Progress_Planner\Admin\Page();
 			$this->cached['admin__tour']                   = new \Progress_Planner\Admin\Tour();
 			$this->cached['admin__dashboard_widget_score'] = new \Progress_Planner\Admin\Dashboard_Widget_Score();


### PR DESCRIPTION
## Context
Currently we show display widgets for authors and above roles. I believe this was a mistake since we dont want authors to Add / Remove TODO tasks and complete suggested tasks.

If I am wrong and we want to revert this change then [this section](https://github.com/Emilia-Capital/progress-planner/blob/a9bd8024cbf65fbd6d4b9a953a01b0c631f8c99a/classes/suggested-tasks/local-tasks/class-update-content.php#L208-L247) needs to be updated since `get_edit_post_link` returns null for authors (which results in PHP warning from `esc_url`)

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

