### PR TITLE
Information icon for 'Create a long post' task shows text of 'create a short post' task

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/class-content-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-create.php
@@ -171,12 +171,12 @@ class Content_Create extends Content_Abstract implements \Progress_Planner\Sugge
 			'description' => isset( $data['long'] ) && $data['long']
 				? sprintf(
 					/* translators: %d: The threshold (number, words count) for a long post. */
-					esc_html__( 'Create a new short post (no longer than %d words).', 'progress-planner' ),
+					esc_html__( 'Create a new long post (longer than %d words).', 'progress-planner' ),
 					\Progress_Planner\Activities\Content_Helpers::LONG_POST_THRESHOLD
 				)
 				: sprintf(
 					/* translators: %d: The threshold (number, words count) for a long post. */
-					esc_html__( 'Create a new long post (longer than %d words).', 'progress-planner' ),
+					esc_html__( 'Create a new short post (no longer than %d words).', 'progress-planner' ),
 					\Progress_Planner\Activities\Content_Helpers::LONG_POST_THRESHOLD
 				),
 		];


### PR DESCRIPTION
## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes https://github.com/Emilia-Capital/progress-planner/issues/168
