### PR TITLE
Define remote url constant as a (global) constant

### DIFF
--- a/assets/js/web-components/prpl-badge.js
+++ b/assets/js/web-components/prpl-badge.js
@@ -1,4 +1,4 @@
-/* global customElements, HTMLElement */
+/* global customElements, HTMLElement, progressPlannerBadge */
 
 /**
  * Register the custom web component.
@@ -13,7 +13,9 @@ customElements.define(
 				true === complete && 'true' === this.getAttribute( 'complete' );
 			this.innerHTML = `
 				<img
-					src="https://progressplanner.com/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=${
+					src="${
+						progressPlannerBadge.remoteServerRootUrl
+					}/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=${
 						badgeId || this.getAttribute( 'badge-id' )
 					}"
 					alt="Badge"

--- a/classes/admin/class-scripts.php
+++ b/classes/admin/class-scripts.php
@@ -96,6 +96,15 @@ class Scripts {
 	 */
 	public function localize_script( $handle ) {
 		switch ( $handle ) {
+			case 'progress-planner-web-components-prpl-badge':
+				\wp_localize_script(
+					$handle,
+					'progressPlannerBadge',
+					[
+						'remoteServerRootUrl' => PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL,
+					]
+				);
+				break;
 			case 'progress-planner-web-components-prpl-suggested-task':
 				\wp_localize_script(
 					$handle,

--- a/classes/class-lessons.php
+++ b/classes/class-lessons.php
@@ -44,7 +44,7 @@ class Lessons {
 	public function get_remote_api_items() {
 		$url             = \add_query_arg(
 			[ 'site' => \get_site_url() ],
-			'https://progressplanner.com/wp-json/progress-planner-saas/v1/lessons'
+			PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL . '/wp-json/progress-planner-saas/v1/lessons'
 		);
 		$pro_license_key = \get_option( 'progress_planner_pro_license_key' );
 		if ( $pro_license_key && 'valid' === \get_option( 'progress_planner_pro_license_status' ) ) {

--- a/classes/class-onboard.php
+++ b/classes/class-onboard.php
@@ -13,13 +13,6 @@ namespace Progress_Planner;
 class Onboard {
 
 	/**
-	 * The remote server URL.
-	 *
-	 * @var string
-	 */
-	const REMOTE_SERVER_ROOT_URL = 'https://progressplanner.com';
-
-	/**
 	 * The remote API endpoints namespace URL.
 	 *
 	 * @var string
@@ -94,7 +87,7 @@ class Onboard {
 	 * @return string
 	 */
 	public function get_remote_nonce_url() {
-		return self::REMOTE_SERVER_ROOT_URL . self::REMOTE_API_URL . 'get-nonce';
+		return PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL . self::REMOTE_API_URL . 'get-nonce';
 	}
 
 	/**
@@ -103,6 +96,6 @@ class Onboard {
 	 * @return string
 	 */
 	public function get_remote_url() {
-		return self::REMOTE_SERVER_ROOT_URL . self::REMOTE_API_URL . 'onboard';
+		return PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL . self::REMOTE_API_URL . 'onboard';
 	}
 }

--- a/classes/suggested-tasks/class-remote-tasks.php
+++ b/classes/suggested-tasks/class-remote-tasks.php
@@ -37,6 +37,9 @@ class Remote_Tasks {
 		$inject_items = $this->get_tasks_to_inject();
 		$items        = [];
 		foreach ( $inject_items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
 			$item['task_id'] = "remote-task-{$item['task_id']}";
 			$items[]         = $item;
 		}

--- a/classes/suggested-tasks/class-remote-tasks.php
+++ b/classes/suggested-tasks/class-remote-tasks.php
@@ -74,9 +74,15 @@ class Remote_Tasks {
 				$tasks = \json_decode( $body, true );
 
 				if ( \is_array( $tasks ) ) {
+					$valid_tasks = [];
+					foreach ( $tasks as $task ) {
+						if ( isset( $task['task_id'] ) ) {
+							$valid_tasks[] = $task;
+						}
+					}
 					// Cache the response for 1 day.
-					\progress_planner()->get_cache()->set( self::CACHE_KEY, $tasks, DAY_IN_SECONDS );
-					return $tasks;
+					\progress_planner()->get_cache()->set( self::CACHE_KEY, $valid_tasks, DAY_IN_SECONDS );
+					return $valid_tasks;
 				}
 			}
 		}

--- a/classes/suggested-tasks/class-remote-tasks.php
+++ b/classes/suggested-tasks/class-remote-tasks.php
@@ -13,13 +13,6 @@ namespace Progress_Planner\Suggested_Tasks;
 class Remote_Tasks {
 
 	/**
-	 * The remote server URL.
-	 *
-	 * @var string
-	 */
-	const REMOTE_SERVER_ROOT_URL = 'https://progressplanner.com';
-
-	/**
 	 * The cache key to use for remote-API tasks.
 	 *
 	 * @var string
@@ -93,7 +86,7 @@ class Remote_Tasks {
 	 * @return string
 	 */
 	protected function get_api_endpoint() {
-		$url             = self::REMOTE_SERVER_ROOT_URL . '/wp-json/progress-planner-saas/v1/suggested-todo/';
+		$url             = PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL . '/wp-json/progress-planner-saas/v1/suggested-todo/';
 		$pro_license_key = \get_option( 'progress_planner_pro_license_key' );
 		if ( $pro_license_key ) {
 			$url = \add_query_arg(

--- a/classes/widgets/class-latest-badge.php
+++ b/classes/widgets/class-latest-badge.php
@@ -24,5 +24,5 @@ final class Latest_Badge extends \Progress_Planner\Widget {
 	 *
 	 * @var string
 	 */
-	public $endpoint = 'https://progressplanner.com/wp-json/progress-planner-saas/v1/share-badge-image?badge=';
+	public $endpoint = PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL . '/wp-json/progress-planner-saas/v1/share-badge-image?badge=';
 }

--- a/classes/widgets/class-whats-new.php
+++ b/classes/widgets/class-whats-new.php
@@ -13,13 +13,6 @@ namespace Progress_Planner\Widgets;
 final class Whats_New extends \Progress_Planner\Widget {
 
 	/**
-	 * The remote server ROOT URL.
-	 *
-	 * @var string
-	 */
-	const REMOTE_SERVER_ROOT_URL = 'https://progressplanner.com';
-
-	/**
 	 * The cache key.
 	 *
 	 * @var string
@@ -60,7 +53,7 @@ final class Whats_New extends \Progress_Planner\Widget {
 		// Transient expired, fetch new feed.
 		if ( $feed_data['expires'] < time() ) {
 			// Get the feed using the REST API.
-			$response = \wp_remote_get( self::REMOTE_SERVER_ROOT_URL . '/wp-json/wp/v2/posts/?per_page=2' );
+			$response = \wp_remote_get( PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL . '/wp-json/wp/v2/posts/?per_page=2' );
 
 			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 				// If we cant fetch the feed, we will try again later.
@@ -72,7 +65,7 @@ final class Whats_New extends \Progress_Planner\Widget {
 					// Get the featured media.
 					$featured_media_id = $post['featured_media'];
 					if ( $featured_media_id ) {
-						$response = \wp_remote_get( self::REMOTE_SERVER_ROOT_URL . '/wp-json/wp/v2/media/' . $featured_media_id );
+						$response = \wp_remote_get( PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL . '/wp-json/wp/v2/media/' . $featured_media_id );
 						if ( ! \is_wp_error( $response ) ) {
 							$media = json_decode( \wp_remote_retrieve_body( $response ), true );
 

--- a/progress-planner.php
+++ b/progress-planner.php
@@ -26,6 +26,10 @@ define( 'PROGRESS_PLANNER_FILE', __FILE__ );
 define( 'PROGRESS_PLANNER_DIR', __DIR__ );
 define( 'PROGRESS_PLANNER_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
 
+if ( ! defined( 'PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL' ) ) {
+	define( 'PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL', 'https://progressplanner.com' );
+}
+
 /**
  * Autoload classes.
  */

--- a/views/page-widgets/latest-badge.php
+++ b/views/page-widgets/latest-badge.php
@@ -46,7 +46,7 @@ $prpl_latest_badge = \progress_planner()->get_badges()->get_latest_completed_bad
 				'badge' => $prpl_latest_badge->get_id(),
 				'url'   => \home_url(),
 			],
-			'https://progressplanner.com/wp-json/progress-planner-saas/v1/share-badge'
+			PROGRESS_PLANNER_REMOTE_SERVER_ROOT_URL . '/wp-json/progress-planner-saas/v1/share-badge'
 		);
 		?>
 		<div class="share-badge-wrapper">


### PR DESCRIPTION
## Context

We have our remote server URL defined in many places, it is defined for every use case separately.

This PR defines it as a global PHP constant which makes it consistent. 
Also `is_defined` allows us to easily change URL in case we want to set up server instance locally or in a staging environment.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
