### PR TITLE
Prevent celebration when old post is moved to trash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Fixed:
 * Confetti being triggered on every page load.
 * Assets versioning.
 * Duplicate update-core tasks.
+* Update old post task being celebrated as completed when post is trashed.
 * Information icon for 'Create a long post' task was showing text of 'create a short post' task.
 * Numerous other minor bugfixes.
 

--- a/classes/suggested-tasks/local-tasks/providers/class-content-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-update.php
@@ -31,6 +31,8 @@ class Content_Update extends Content_Abstract implements \Progress_Planner\Sugge
 	 */
 	public function __construct() {
 		\add_filter( 'progress_planner_update_posts_tasks_args', [ $this, 'filter_update_posts_args' ] );
+
+		\add_action( 'transition_post_status', [ $this, 'transition_post_status' ], 10, 3 );
 	}
 
 	/**
@@ -155,5 +157,34 @@ class Content_Update extends Content_Abstract implements \Progress_Planner\Sugge
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Run actions when transitioning a post status.
+	 *
+	 * @param string   $new_status The new status.
+	 * @param string   $old_status The old status.
+	 * @param \WP_Post $post       The post object.
+	 *
+	 * @return void
+	 */
+	public function transition_post_status( $new_status, $old_status, $post ) {
+		$include_post_types = \progress_planner()->get_settings()->get( [ 'include_post_types' ], [ 'post', 'page' ] );
+
+		// Bail if we should skip saving.
+		if ( ( 'trash' !== $new_status )
+			|| ! \in_array( $post->post_type, $include_post_types, true )
+		) {
+			return;
+		}
+
+		foreach ( \progress_planner()->get_suggested_tasks()->get_local()->get_pending_tasks() as $task_id ) {
+			$task_object = \Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory::create( $task_id );
+			$task_data   = $task_object->get_data();
+			if ( self::TYPE === $task_data['type'] && ( isset( $task_data['post_id'] ) && (int) $task_data['post_id'] === (int) $post->ID ) ) {
+				// Remove the task from the pending local tasks list.
+				\progress_planner()->get_suggested_tasks()->get_local()->remove_pending_task( $task_id ); // @phpstan-ignore-line method.nonObject
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Context

When we have a Suggested task to update old post (older than 6 months) we check if that task was completed by checking post modified time. Unfortunately, modified time is also updated when post is trashed (without making any changes to the content) which results in confetti celebration without post displayed in Suggested tasks list.

This PR removes `update post` task from local tasks list when post is trashed.


## Summary

This PR can be summarized in the following changelog entry:
Remove trashed posts from suggested tasks.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] I have checked that the base branch is correctly set.
