### PR TITLE
Check user capability for suggested tasks

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/class-content-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-abstract.php
@@ -10,7 +10,14 @@ namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
 /**
  * Add tasks for content updates.
  */
-abstract class Content_Abstract {
+abstract class Content_Abstract extends Local_Tasks_Abstract {
+
+	/**
+	 * The capability required to perform the task.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'edit_others_posts';
 
 	/**
 	 * Get the task ID.

--- a/classes/suggested-tasks/local-tasks/providers/class-content-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-create.php
@@ -7,13 +7,12 @@
 
 namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
 
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks_Interface;
 use Progress_Planner\Activities\Content_Helpers;
 
 /**
  * Add tasks for content creation.
  */
-class Content_Create extends Content_Abstract implements Local_Tasks_Interface {
+class Content_Create extends Content_Abstract {
 
 	/**
 	 * The provider ID.
@@ -185,14 +184,5 @@ class Content_Create extends Content_Abstract implements Local_Tasks_Interface {
 		];
 
 		return $task_details;
-	}
-
-	/**
-	 * Check if the user has the capability to create a post.
-	 *
-	 * @return bool
-	 */
-	public function capability_required() {
-		return \current_user_can( 'edit_others_posts' );
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-content-create.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-create.php
@@ -186,4 +186,13 @@ class Content_Create extends Content_Abstract implements Local_Tasks_Interface {
 
 		return $task_details;
 	}
+
+	/**
+	 * Check if the user has the capability to create a post.
+	 *
+	 * @return bool
+	 */
+	public function capability_required() {
+		return \current_user_can( 'edit_others_posts' );
+	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-content-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-update.php
@@ -8,12 +8,11 @@
 namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
 
 use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks_Interface;
 
 /**
  * Add tasks for content updates.
  */
-class Content_Update extends Content_Abstract implements Local_Tasks_Interface {
+class Content_Update extends Content_Abstract {
 
 	/**
 	 * The provider ID.
@@ -189,14 +188,5 @@ class Content_Update extends Content_Abstract implements Local_Tasks_Interface {
 				\progress_planner()->get_suggested_tasks()->get_local()->remove_pending_task( $task_id ); // @phpstan-ignore-line method.nonObject
 			}
 		}
-	}
-
-	/**
-	 * Check if the user has the capability to update a post.
-	 *
-	 * @return bool
-	 */
-	public function capability_required() {
-		return \current_user_can( 'edit_others_posts' );
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-content-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-update.php
@@ -190,4 +190,13 @@ class Content_Update extends Content_Abstract implements Local_Tasks_Interface {
 			}
 		}
 	}
+
+	/**
+	 * Check if the user has the capability to update a post.
+	 *
+	 * @return bool
+	 */
+	public function capability_required() {
+		return \current_user_can( 'edit_others_posts' );
+	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-update.php
@@ -7,12 +7,17 @@
 
 namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
 
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks_Interface;
-
 /**
  * Add tasks for Core updates.
  */
-class Core_Update implements Local_Tasks_Interface {
+class Core_Update extends Local_Tasks_Abstract {
+
+	/**
+	 * The capability required to perform the task.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'update_core';
 
 	/**
 	 * The provider ID.
@@ -137,14 +142,5 @@ class Core_Update implements Local_Tasks_Interface {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Check if the user has the capability to update the core.
-	 *
-	 * @return bool
-	 */
-	public function capability_required() {
-		return \current_user_can( 'update_core' );
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks-abstract.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks-abstract.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Abstract class for a local task provider.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
+
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks_Interface;
+
+/**
+ * Add tasks for content updates.
+ */
+abstract class Local_Tasks_Abstract implements Local_Tasks_Interface {
+
+	/**
+	 * The capability required to perform the task.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Check if the user has the capability to perform the task.
+	 *
+	 * @return bool
+	 */
+	public function capability_required() {
+		return $this->capability
+			? \current_user_can( $this->capability )
+			: true;
+	}
+}

--- a/classes/suggested-tasks/local-tasks/providers/class-local-tasks-interface.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-local-tasks-interface.php
@@ -52,4 +52,11 @@ interface Local_Tasks_Interface {
 	 * @return string
 	 */
 	public function get_provider_type();
+
+	/**
+	 * Check if the user has the capability to perform the task.
+	 *
+	 * @return bool
+	 */
+	public function capability_required();
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
@@ -38,6 +38,12 @@ class Settings_Saved implements Local_Tasks_Interface {
 	 * @return bool|string
 	 */
 	public function evaluate_task( $task_id ) {
+
+		// Early bail if the user does not have the capability to manage options.
+		if ( ! $this->capability_required() ) {
+			return false;
+		}
+
 		if ( 0 === strpos( $task_id, self::TYPE ) && false !== \get_option( 'progress_planner_pro_license_key', false ) ) {
 			return $task_id;
 		}
@@ -50,7 +56,9 @@ class Settings_Saved implements Local_Tasks_Interface {
 	 * @return array
 	 */
 	public function get_tasks_to_inject() {
-		if ( true === $this->is_task_type_snoozed() ) {
+
+		// Early bail if the user does not have the capability to manage options or if the task is snoozed.
+		if ( true === $this->is_task_type_snoozed() || ! $this->capability_required() ) {
 			return [];
 		}
 
@@ -93,7 +101,7 @@ class Settings_Saved implements Local_Tasks_Interface {
 			'priority'    => 'high',
 			'type'        => 'maintenance',
 			'points'      => 1,
-			'url'         => \esc_url( \admin_url( 'admin.php?page=progress-planner-settings' ) ),
+			'url'         => \current_user_can( 'manage_options' ) ? \esc_url( \admin_url( 'admin.php?page=progress-planner-settings' ) ) : '',
 			'description' => '<p>' . \esc_html__( 'Head over to the settings page and fill in the required information.', 'progress-planner' ) . '</p>',
 		];
 	}
@@ -132,5 +140,14 @@ class Settings_Saved implements Local_Tasks_Interface {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check if the user has the capability to manage options.
+	 *
+	 * @return bool
+	 */
+	public function capability_required() {
+		return \current_user_can( 'manage_options' );
 	}
 }

--- a/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-settings-saved.php
@@ -7,12 +7,10 @@
 
 namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
 
-use Progress_Planner\Suggested_Tasks\Local_Tasks\Providers\Local_Tasks_Interface;
-
 /**
  * Add tasks for settings saved.
  */
-class Settings_Saved implements Local_Tasks_Interface {
+class Settings_Saved extends Local_Tasks_Abstract {
 
 	/**
 	 * The provider ID.
@@ -140,14 +138,5 @@ class Settings_Saved implements Local_Tasks_Interface {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Check if the user has the capability to manage options.
-	 *
-	 * @return bool
-	 */
-	public function capability_required() {
-		return \current_user_can( 'manage_options' );
 	}
 }

--- a/classes/widgets/class-suggested-tasks.php
+++ b/classes/widgets/class-suggested-tasks.php
@@ -9,6 +9,7 @@ namespace Progress_Planner\Widgets;
 
 use Progress_Planner\Widget;
 use Progress_Planner\Badges\Monthly;
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 
 /**
  * Suggested_Tasks class.
@@ -100,16 +101,21 @@ final class Suggested_Tasks extends Widget {
 		// Insert the pending celebration tasks as high priority tasks, so they are shown always.
 		foreach ( $tasks['pending_celebration'] as $task_id ) {
 
-			$task_details = \progress_planner()->get_suggested_tasks()->get_local()->get_task_details( $task_id );
+			$task_object   = ( new Local_Task_Factory( $task_id ) )->get_task();
+			$task_provider = \progress_planner()->get_suggested_tasks()->get_local()->get_task_provider( $task_object->get_provider_type() );
 
-			if ( $task_details ) {
-				$task_details['priority'] = 'high'; // Celebrate tasks are always on top.
-				$task_details['action']   = 'celebrate';
-				$tasks['details'][]       = $task_details;
+			if ( $task_provider->capability_required() ) {
+				$task_details = \progress_planner()->get_suggested_tasks()->get_local()->get_task_details( $task_id );
+
+				if ( $task_details ) {
+					$task_details['priority'] = 'high'; // Celebrate tasks are always on top.
+					$task_details['action']   = 'celebrate';
+					$tasks['details'][]       = $task_details;
+				}
+
+				// Mark the pending celebration tasks as completed.
+				\progress_planner()->get_suggested_tasks()->transition_task_status( $task_id, 'pending_celebration', 'completed' );
 			}
-
-			// Mark the pending celebration tasks as completed.
-			\progress_planner()->get_suggested_tasks()->transition_task_status( $task_id, 'pending_celebration', 'completed' );
 		}
 
 		// Localize the script.

--- a/views/dashboard-widgets/score.php
+++ b/views/dashboard-widgets/score.php
@@ -37,9 +37,11 @@ use Progress_Planner\Badges\Monthly;
 <ul style="display:none"></ul>
 <ul class="prpl-suggested-tasks-list"></ul>
 
-<div class="prpl-dashboard-widget-footer">
-	<img src="<?php echo \esc_attr( PROGRESS_PLANNER_URL . '/assets/images/icon_progress_planner.svg' ); ?>" style="width:1.5em;" alt="" />
-	<a href="<?php echo \esc_url( \get_admin_url( null, 'admin.php?page=progress-planner' ) ); ?>">
-		<?php \esc_html_e( 'Check out all your stats and badges', 'progress-planner' ); ?>
-	</a>
-</div>
+<?php if ( \current_user_can( 'manage_options' ) ) : ?>
+	<div class="prpl-dashboard-widget-footer">
+		<img src="<?php echo \esc_attr( PROGRESS_PLANNER_URL . '/assets/images/icon_progress_planner.svg' ); ?>" style="width:1.5em;" alt="" />
+		<a href="<?php echo \esc_url( \get_admin_url( null, 'admin.php?page=progress-planner' ) ); ?>">
+			<?php \esc_html_e( 'Check out all your stats and badges', 'progress-planner' ); ?>
+		</a>
+	</div>
+<?php endif; ?>


### PR DESCRIPTION
## Context

The issue is that tasks were always added to the Suggested tasks list, even if current user doesnt have capability to perform them. Good examples are `Update Core` and `Fill settings page` tasks. 

So for start, tasks links are added conditionally.
Second, I decided to skip adding tasks in such cases to the list until we decide do we want it or not - perhaps we would like to change task description in that case, ie `Ask site admin perform all updates`

Also one weird edge case was that admin could actually peform the task, but if editor was logged in at the same time it could happen that confetti was triggered for him (although editor didnt do anything). That is why the condition to skip "pending_celebration" tasks was added in the `classes/widgets/class-suggested-tasks.php` was added.

I have made a several tests, but needs to be tested a bit more before merging since we're close to the release.


## Quality assurance

* [] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
