### PR TITLE
Clean up local tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+= 1.0.2 =
+
+Fixed:
+
+* Duplicate weekly suggested tasks.
+
 = 1.0.1 =
 
 Fixed:

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -240,6 +240,13 @@ class Local_Tasks_Manager {
 	 * @return void
 	 */
 	public function cleanup_pending_tasks() {
+
+		$cleanup_recently_performed = \progress_planner()->get_cache()->get( 'cleanup_pending_tasks' );
+
+		if ( $cleanup_recently_performed ) {
+			return;
+		}
+
 		$tasks = (array) $this->get_pending_tasks();
 
 		if ( empty( $tasks ) ) {
@@ -265,5 +272,7 @@ class Local_Tasks_Manager {
 		if ( count( $tasks ) !== $task_count ) {
 			\update_option( self::OPTION_NAME, $tasks );
 		}
+
+		\progress_planner()->get_cache()->set( 'cleanup_pending_tasks', true, DAY_IN_SECONDS );
 	}
 }

--- a/classes/suggested-tasks/class-local-tasks-manager.php
+++ b/classes/suggested-tasks/class-local-tasks-manager.php
@@ -51,6 +51,9 @@ class Local_Tasks_Manager {
 
 		\add_filter( 'progress_planner_suggested_tasks_items', [ $this, 'inject_tasks' ] );
 		\add_action( 'plugins_loaded', [ $this, 'add_plugin_integration' ] );
+
+		// Add the cleanup action.
+		\add_action( 'admin_init', [ $this, 'cleanup_pending_tasks' ] );
 	}
 
 	/**
@@ -228,5 +231,39 @@ class Local_Tasks_Manager {
 		$tasks = (array) $this->get_pending_tasks();
 		$tasks = \array_diff( $tasks, [ $task ] );
 		return \update_option( self::OPTION_NAME, $tasks );
+	}
+
+	/**
+	 * Remove all tasks which have date set to the previous week.
+	 * Tasks for the current week will be added automatically.
+	 *
+	 * @return void
+	 */
+	public function cleanup_pending_tasks() {
+		$tasks = (array) $this->get_pending_tasks();
+
+		if ( empty( $tasks ) ) {
+			return;
+		}
+
+		$task_count = count( $tasks );
+
+		$tasks = \array_filter(
+			$tasks,
+			function ( $task ) {
+				$task_object = ( new Local_Task_Factory( $task ) )->get_task();
+				$task_data   = $task_object->get_data();
+
+				if ( isset( $task_data['year_week'] ) ) {
+					return \gmdate( 'YW' ) === $task_data['year_week'];
+				}
+
+				return true;
+			}
+		);
+
+		if ( count( $tasks ) !== $task_count ) {
+			\update_option( self::OPTION_NAME, $tasks );
+		}
 	}
 }

--- a/classes/suggested-tasks/local-tasks/class-local-task-factory.php
+++ b/classes/suggested-tasks/local-tasks/class-local-task-factory.php
@@ -42,10 +42,15 @@ class Local_Task_Factory {
 				return new Task_Local( [ 'task_id' => $this->task_id ] );
 			}
 
+			$type        = substr( $this->task_id, 0, $last_pos );
+			$task_suffix = substr( $this->task_id, $last_pos + 1 );
+
+			$task_suffix_key = 'remote-task' === $type ? 'remote_task_id' : 'year_week';
+
 			return new Task_Local(
 				[
-					'type'      => substr( $this->task_id, 0, $last_pos ),
-					'year_week' => substr( $this->task_id, $last_pos + 1 ),
+					'type'           => $type,
+					$task_suffix_key => $task_suffix,
 				]
 			);
 		}

--- a/classes/suggested-tasks/local-tasks/providers/class-core-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-core-update.php
@@ -7,6 +7,7 @@
 
 namespace Progress_Planner\Suggested_Tasks\Local_Tasks\Providers;
 
+use Progress_Planner\Suggested_Tasks\Local_Tasks\Local_Task_Factory;
 /**
  * Add tasks for Core updates.
  */
@@ -54,7 +55,10 @@ class Core_Update extends Local_Tasks_Abstract {
 			require_once ABSPATH . 'wp-admin/includes/update.php'; // @phpstan-ignore requireOnce.fileNotFound
 		}
 
-		if ( 0 === strpos( $task_id, self::TYPE ) && 0 === \wp_get_update_data()['counts']['total'] ) {
+		$task_object = ( new Local_Task_Factory( $task_id ) )->get_task();
+		$task_data   = $task_object->get_data();
+
+		if ( $task_data['type'] === self::TYPE && \gmdate( 'YW' ) === $task_data['year_week'] && 0 === \wp_get_update_data()['counts']['total'] ) {
 			return $task_id;
 		}
 		return false;
@@ -136,7 +140,9 @@ class Core_Update extends Local_Tasks_Abstract {
 		}
 
 		foreach ( $snoozed as $task ) {
-			if ( self::TYPE === $task['id'] ) {
+			$task_object = ( new Local_Task_Factory( $task['id'] ) )->get_task();
+			$task_data   = $task_object->get_data();
+			if ( $task_data['type'] === self::TYPE ) {
 				return true;
 			}
 		}

--- a/tests/phpunit/test-class-suggested-tasks.php
+++ b/tests/phpunit/test-class-suggested-tasks.php
@@ -28,7 +28,7 @@ class Suggested_Tasks_Test extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function set_up() {
-		$this->suggested_tasks = new Suggested_Tasks();
+		$this->suggested_tasks = \progress_planner()->get_suggested_tasks();
 	}
 
 	/**
@@ -95,5 +95,39 @@ class Suggested_Tasks_Test extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_maybe_unsnooze_tasks() {
+	}
+
+	/**
+	 * Test the task_cleanup method.
+	 *
+	 * @return void
+	 */
+	public function test_task_cleanup() {
+		// Tasks that should not be removed.
+		$tasks_to_keep = [
+			'remote-task-1234',
+			'post_id/14|type/update-post',
+			'date/202452|long/0|type/create-post',
+			'update-core-' . \gmdate( 'YW' ),
+			'settings-saved-' . \gmdate( 'YW' ),
+		];
+
+		foreach ( $tasks_to_keep as $task_id ) {
+			$this->suggested_tasks->get_local()->add_pending_task( $task_id );
+		}
+
+		// Tasks that should be removed.
+		$tasks_to_remove = [
+			'update-core-202451',
+			'settings-saved-202451',
+		];
+
+		foreach ( $tasks_to_remove as $task_id ) {
+			$this->suggested_tasks->get_local()->add_pending_task( $task_id );
+		}
+
+		$this->suggested_tasks->get_local()->cleanup_pending_tasks();
+
+		$this->assertEquals( count( $tasks_to_keep ), \count( $this->suggested_tasks->get_local()->get_pending_tasks() ) );
 	}
 }


### PR DESCRIPTION
## Context

For some type of suggested tasks (create new short / long post, update core) we use year and week as part of their ID - this way we can generate new tasks of the same type periodically and also prevent user to do the same task infinite number of times during the same week (ie to create long / short repeatedly).

For https://github.com/Emilia-Capital/progress-planner/pull/163 I changed format of the `update-core `task to include year and week, but I haven't updated all the checks properly - so the `update-core` task is added to the local (suggested) tasks list again when the next week starts. It is not visible to the user (it is not displayed in the widget) but upon completion 2 update tasks would be struck through and user would get 2 points.

On the other side, create new short / long post had a check if completed task(s) was generated within the current week, so points are awarded correctly, but with the same problem of task(s) of the same type being internally added when new week starts.

I have looked into several ways on how to fix this and the least invasive and IMO the best approach is to:
- add a check for completed `update-core` tasks if they were generated in the current week (like we had for create post tasks)
- add a cleanup method which will remove uncompleted tasks which were generated in the previous week (this runs once a day)


## Summary

This PR can be summarized in the following changelog entry:

Remove duplicate weekly suggested tasks.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

