### PR TITLE
Fix get-stats API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+= 1.0.2 =
+
+Fixed:
+
+* Fixed the REST API endpoint for getting stats.
+
 = 1.0.1 =
 
 Fixed:

--- a/classes/class-rest-api-stats.php
+++ b/classes/class-rest-api-stats.php
@@ -99,7 +99,7 @@ class Rest_API_Stats {
 		$badges = array_merge(
 			\progress_planner()->get_badges()->get_badges( 'content' ),
 			\progress_planner()->get_badges()->get_badges( 'maintenance' ),
-			\progress_planner()->get_badges()->get_badges( 'monthly' )
+			\progress_planner()->get_badges()->get_badges( 'monthly_flat' )
 		);
 
 		$data['badges'] = [];

--- a/tests/phpunit/test-class-api-get-stats.php
+++ b/tests/phpunit/test-class-api-get-stats.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Class Test_API_Get_Stats
+ *
+ * @package Progress_Planner\Tests
+ */
+
+namespace Progress_Planner\Tests;
+
+use WP_UnitTestCase;
+use WP_REST_Server;
+use WP_REST_Request;
+
+/**
+ * Test_API_Get_Stats test case.
+ */
+class Test_API_Get_Stats extends \WP_UnitTestCase {
+
+	/**
+	 * Holds the WP REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * The token for the test.
+	 *
+	 * @var string
+	 */
+	private $token;
+
+	/**
+	 * Create a item for our test and initiate REST API.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->token = '123456789';
+
+		// Add a fake license key.
+		update_option( 'progress_planner_license_key', $this->token );
+
+		// Initiating the REST API.
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Delete the item after the test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		// Delete the fake license key.
+		delete_option( 'progress_planner_license_key' );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+	}
+
+	/**
+	 * Test the endpoint for Person CPT.
+	 *
+	 * @return void.
+	 */
+	public function testEndpoint() {
+
+		$request  = new WP_REST_Request( 'GET', '/progress-planner/v1/get-stats/' . $this->token );
+		$response = $this->server->dispatch( $request );
+
+		// Check if the response is successful.
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Get the data.
+		$data = $response->get_data();
+
+		// Check if the data has the expected keys.
+		$data_to_check = [
+			'pending_updates',
+			'weekly_posts',
+			'activities',
+			'website_activity',
+			'badges',
+			'latest_badge',
+			'scores',
+			'website',
+			'timezone_offset',
+			'todo',
+			'plugin_url',
+		];
+
+		foreach ( $data_to_check as $key ) {
+			$this->assertArrayHasKey( $key, $data );
+		}
+	}
+}


### PR DESCRIPTION
## Context

In https://github.com/Emilia-Capital/progress-planner/pull/173 we changed the way monthly badges are inited, besides to match the design it was done to solve the problem with with initing badges when we enter the new year.

Unfortunately this broke the get-stats API endpoint, since monthly badges are returned by default in different format.

This PR fixes that and since manually testing the endpoint is a bit of a pain (you need to be registered and pass the license key with the request) I added the PHP Unit test which verifies that that endpoint works as expected.


## Summary

This PR can be summarized in the following changelog entry:

Fixed the REST API endpoint for getting stats.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

