### PR TITLE
Refactor post_updated and wp_insert_post callbacks

### DIFF
--- a/classes/actions/class-content.php
+++ b/classes/actions/class-content.php
@@ -27,59 +27,14 @@ class Content {
 	 * @return void
 	 */
 	public function register_hooks() {
-		// Add activity when a post is updated.
-		\add_action( 'post_updated', [ $this, 'post_updated' ], 10, 2 );
 
-		// Add activity when a post is added.
-		\add_action( 'wp_insert_post', [ $this, 'insert_post' ], 10, 2 );
+		// Add activity when a post is added or updated.
+		\add_action( 'wp_insert_post', [ $this, 'insert_post' ], 10, 3 );
 		\add_action( 'transition_post_status', [ $this, 'transition_post_status' ], 10, 3 );
 
 		// Add activity when a post is trashed or deleted.
 		\add_action( 'wp_trash_post', [ $this, 'trash_post' ] );
 		\add_action( 'delete_post', [ $this, 'delete_post' ] );
-	}
-
-	/**
-	 * Post updated.
-	 *
-	 * Runs on post_updated hook.
-	 *
-	 * @param int      $post_id The post ID.
-	 * @param \WP_Post $post    The post object.
-	 *
-	 * @return void
-	 */
-	public function post_updated( $post_id, $post ) {
-		// Bail if we should skip saving.
-		if ( $this->should_skip_saving( $post ) ) {
-			return;
-		}
-
-		// Reset the words count.
-		\progress_planner()->get_settings()->set( [ 'word_count', $post_id ], false );
-
-		if ( 'publish' !== $post->post_status ) {
-			return;
-		}
-
-		// Check if there is an update activity for this post, on this date.
-		$existing = \progress_planner()->get_query()->query_activities(
-			[
-				'category'   => 'content',
-				'type'       => 'update',
-				'data_id'    => (string) $post_id,
-				'start_date' => \progress_planner()->get_date()->get_datetime_from_mysql_date( $post->post_modified )->modify( '-12 hours' ),
-				'end_date'   => \progress_planner()->get_date()->get_datetime_from_mysql_date( $post->post_modified )->modify( '+12 hours' ),
-			],
-			'RAW'
-		);
-
-		// If there is an update activity for this post, on this date, bail.
-		if ( ! empty( $existing ) ) {
-			return;
-		}
-
-		$this->add_post_activity( $post, 'update' );
 	}
 
 	/**
@@ -89,35 +44,54 @@ class Content {
 	 *
 	 * @param int      $post_id The post ID.
 	 * @param \WP_Post $post    The post object.
+	 * @param bool     $update  Whether this is an update.
 	 * @return void
 	 */
-	public function insert_post( $post_id, $post ) {
+	public function insert_post( $post_id, $post, $update ) {
 		// Bail if we should skip saving.
 		if ( $this->should_skip_saving( $post ) ) {
 			return;
 		}
 
+		// Set the type of activity.
+		$type = $update ? 'update' : 'publish';
+
+		// Reset the words count if it's an update.
+		if ( 'update' === $type ) {
+			\progress_planner()->get_settings()->set( [ 'word_count', $post_id ], false );
+		}
+
+		// Bail if the post is not published.
 		if ( 'publish' !== $post->post_status ) {
 			return;
 		}
 
-		// Check if there is a publish activity for this post.
+		// Query arguments.
+		$query_args = [
+			'category' => 'content',
+			'type'     => $type,
+			'data_id'  => (string) $post_id,
+		];
+
+		// If it's an update add the start and end date. We don't want to add multiple update activities for the same post on the same day.
+		if ( 'update' === $type ) {
+			$query_args['start_date'] = \progress_planner()->get_date()->get_datetime_from_mysql_date( $post->post_modified )->modify( '-12 hours' );
+			$query_args['end_date']   = \progress_planner()->get_date()->get_datetime_from_mysql_date( $post->post_modified )->modify( '+12 hours' );
+		}
+
+		// Check if there is an activity for this post.
 		$existing = \progress_planner()->get_query()->query_activities(
-			[
-				'category' => 'content',
-				'type'     => 'publish',
-				'data_id'  => (string) $post_id,
-			],
+			$query_args,
 			'RAW'
 		);
 
-		// If there is a publish activity for this post, bail.
+		// If there is an activity for this post, bail.
 		if ( ! empty( $existing ) ) {
 			return;
 		}
 
-		// Add a publish activity.
-		$this->add_post_activity( $post, 'publish' );
+		// Finally add an activity.
+		$this->add_post_activity( $post, $type );
 	}
 
 	/**


### PR DESCRIPTION
## Context

This PR solves the issue we have described in https://github.com/Emilia-Capital/progress-planner/issues/122 .

While testing after refactoring I found a bug, the refactored method was working fine but the problem was in [transition_post_status](https://github.com/Emilia-Capital/progress-planner/blob/1a7e4dd3019c277bc52aa710013e23ec680b1a9b/classes/actions/class-content.php#L132-L143) method which allowed multiple `update` activities to be added.

I believe that was wrong since in the `post_updated` method we had a [check](https://github.com/Emilia-Capital/progress-planner/blob/1a7e4dd3019c277bc52aa710013e23ec680b1a9b/classes/actions/class-content.php#L72) for not adding `update` activity if it was already added recently. `transition_post_status` was missing that check so it allowed user to add activities by simply changing the post status, for example from `publish` to `draft` and back from `draft` to `publish`.

If I was wrong then only the 2nd commit needs to be reverted.


## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes https://github.com/Emilia-Capital/progress-planner/issues/122
