### PR TITLE
2025 monthly badges tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 Fixed:
 
 * Duplicate weekly suggested tasks.
-* Fixed the REST API endpoint for getting stats.
+* The REST API endpoint for getting stats.
+* Scrollable monthly badges widget height on page load.
+* 2026 monthly badges showing up
 
 = 1.0.1 =
 

--- a/assets/js/widgets/suggested-tasks.js
+++ b/assets/js/widgets/suggested-tasks.js
@@ -299,8 +299,18 @@ class BadgeScroller {
 	init() {
 		this.addEventListeners();
 
-		// On page load.
-		this.setWrapperHeight();
+		// On page load, when all images are loaded.
+		const images = [ ...this.element.querySelectorAll( 'img' ) ];
+		if ( images.length ) {
+			Promise.all(
+				images.map(
+					( im ) =>
+						new Promise( ( resolve ) => ( im.onload = resolve ) )
+				)
+			).then( () => {
+				this.setWrapperHeight();
+			} );
+		}
 
 		// When popover is opened.
 		document

--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -57,7 +57,7 @@ final class Monthly extends Badge {
 		$start_date      = $activation_date->modify( 'first day of this month' );
 
 		// Year when plugin was released.
-		$end_date = ( 2024 === (int) $start_date->format( 'Y' ) )
+		$end_date = ( 2024 === (int) $start_date->format( 'Y' ) && 2024 === (int) \gmdate( 'Y' ) )
 			? new \DateTime( 'last day of December next year' )
 			: new \DateTime( 'last day of December this year' );
 


### PR DESCRIPTION
## Context
This PR fixes 2 things:

- We have scrollable widget for monthly badges. Because we show only 6 badges per scroll it's height needs to be set dynamically on page load, but that needed to be adjusted to wait explicitly for all images to load since we switched to remote images.
- Second commit fixes the 2026 badges being displayed for users who activated in 2024.

## Summary

This PR can be summarized in the following changelog entry:
* Scrollable monthly badges widget height on page load.
* 2026 monthly badges showing up

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
