### PR TITLE
Fix missing SVN

### DIFF
--- a/.github/workflows/asset-deploy.yml
+++ b/.github/workflows/asset-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@stable
+      uses: 10up/action-wordpress-plugin-asset-update@develop
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       # Deploy the plugin to WordPress.org
       - name: WordPress plugin deploy
         id: deploy
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@develop
         with:
           generate-zip: true
         env:

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -5,6 +5,32 @@ if [ $# -lt 3 ]; then
 	exit 1
 fi
 
+# Function to check if a command exists
+command_exists() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+# Check if SVN is installed
+if command_exists svn; then
+	echo "SVN is already installed."
+else
+	echo "SVN is not installed. Installing SVN..."
+
+	# Update the package list
+	sudo apt-get update -y
+
+	# Install SVN
+	sudo apt-get install -y subversion
+
+	# Verify installation
+	if command_exists svn; then
+		echo "SVN was successfully installed."
+	else
+		echo "Failed to install SVN. Please check your system configuration."
+		exit 1
+	fi
+fi
+
 DB_NAME=$1
 DB_USER=$2
 DB_PASS=$3


### PR DESCRIPTION
The new Ubuntu image that runs actions doesn't contain `svn`, so we need to install that before using it.

This fixes the integration tests, and brings the deploy and asset deploy tasks to `develop` where this has also been fixed.