### PR TITLE
Fix inconsistent monthly badge id

### DIFF
--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -108,6 +108,17 @@ final class Monthly extends Badge {
 	}
 
 	/**
+	 * Get the badge ID from a date.
+	 *
+	 * @param \DateTime $date The date.
+	 *
+	 * @return string
+	 */
+	public static function get_badge_id_from_date( $date ) {
+		return 'monthly-' . $date->format( 'Y' ) . '-m' . $date->format( 'n' );
+	}
+
+	/**
 	 * Get an array of months.
 	 *
 	 * @return array

--- a/classes/class-badges.php
+++ b/classes/class-badges.php
@@ -131,7 +131,7 @@ class Badges {
 		}
 
 		// Clear monthly saved progress.
-		$badge_id      = 'monthly-' . $activities[0]->date->format( 'Y' ) . '-m' . $activities[0]->date->format( 'n' );
+		$badge_id      = Monthly::get_badge_id_from_date( $activities[0]->date );
 		$monthly_badge = $this->get_badge( $badge_id );
 
 		if ( $monthly_badge ) {

--- a/classes/class-badges.php
+++ b/classes/class-badges.php
@@ -131,7 +131,7 @@ class Badges {
 		}
 
 		// Clear monthly saved progress.
-		$badge_id      = 'monthly-' . $activities[0]->date->format( 'Y' ) . '-m' . $activities[0]->date->format( 'm' );
+		$badge_id      = 'monthly-' . $activities[0]->date->format( 'Y' ) . '-m' . $activities[0]->date->format( 'n' );
 		$monthly_badge = $this->get_badge( $badge_id );
 
 		if ( $monthly_badge ) {

--- a/views/dashboard-widgets/score.php
+++ b/views/dashboard-widgets/score.php
@@ -14,7 +14,7 @@ use Progress_Planner\Badges\Monthly;
 			<progress max="<?php echo (int) Monthly::TARGET_POINTS; ?>" value="<?php echo (float) \progress_planner()->get_widgets__suggested_tasks()->get_score(); ?>">
 				<prpl-badge
 					complete="true"
-					badge-id="<?php echo esc_attr( 'monthly-' . gmdate( 'Y' ) . '-m' . (int) gmdate( 'm' ) ); ?>"
+					badge-id="<?php echo esc_attr( 'monthly-' . gmdate( 'Y' ) . '-m' . (int) gmdate( 'n' ) ); ?>"
 				></prpl-badge>
 			</progress>
 		</prpl-gauge>

--- a/views/dashboard-widgets/score.php
+++ b/views/dashboard-widgets/score.php
@@ -14,7 +14,7 @@ use Progress_Planner\Badges\Monthly;
 			<progress max="<?php echo (int) Monthly::TARGET_POINTS; ?>" value="<?php echo (float) \progress_planner()->get_widgets__suggested_tasks()->get_score(); ?>">
 				<prpl-badge
 					complete="true"
-					badge-id="<?php echo esc_attr( 'monthly-' . gmdate( 'Y' ) . '-m' . (int) gmdate( 'n' ) ); ?>"
+					badge-id="<?php echo esc_attr( Monthly::get_badge_id_from_date( new \DateTime() ) ); ?>"
 				></prpl-badge>
 			</progress>
 		</prpl-gauge>

--- a/views/page-widgets/parts/monthly-badges.php
+++ b/views/page-widgets/parts/monthly-badges.php
@@ -37,7 +37,7 @@ $prpl_badges_year = (int) isset( $args['badges_year'] ) ? $args['badges_year'] :
 		$prpl_badges_per_row = 3;
 		$prpl_badges_count   = count( $prpl_badges );
 		$prpl_scroll_to_row  = 1;
-
+		$prpl_current_month_badge_id = Monthly::get_badge_id_from_date( new \DateTime() );
 		if ( 'popover' !== $prpl_location ) {
 
 			$prpl_total_rows = (int) ceil( $prpl_badges_count / $prpl_badges_per_row );
@@ -47,7 +47,7 @@ $prpl_badges_year = (int) isset( $args['badges_year'] ) ? $args['badges_year'] :
 
 			foreach ( $prpl_badges as $prpl_badge ) {
 				++$prpl_current_month_position;
-				if ( 'monthly-' . gmdate( 'Y' ) . '-m' . (int) gmdate( 'n' ) === $prpl_badge->get_id() ) {
+				if ( $prpl_current_month_badge_id === $prpl_badge->get_id() ) {
 					break;
 				}
 			}

--- a/views/page-widgets/parts/monthly-badges.php
+++ b/views/page-widgets/parts/monthly-badges.php
@@ -47,7 +47,7 @@ $prpl_badges_year = (int) isset( $args['badges_year'] ) ? $args['badges_year'] :
 
 			foreach ( $prpl_badges as $prpl_badge ) {
 				++$prpl_current_month_position;
-				if ( 'monthly-' . gmdate( 'Y' ) . '-m' . (int) gmdate( 'm' ) === $prpl_badge->get_id() ) {
+				if ( 'monthly-' . gmdate( 'Y' ) . '-m' . (int) gmdate( 'n' ) === $prpl_badge->get_id() ) {
 					break;
 				}
 			}

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $prpl_widget = \progress_planner()->get_widgets__suggested_tasks();
-$prpl_badge  = \progress_planner()->get_badges()->get_badge( 'monthly-' . \gmdate( 'Y' ) . '-m' . (int) \gmdate( 'n' ) );
+$prpl_badge  = \progress_planner()->get_badges()->get_badge( Monthly::get_badge_id_from_date( new \DateTime() ) );
 ?>
 <?php if ( $prpl_badge ) : ?>
 	<h2 class="prpl-widget-title">


### PR DESCRIPTION
## Context

Our monthly badges have id similar to `monthly-2025-m1`, the month part is without leading zero.
In several places we were generating monthly badge id with leading zero, which led to some checks failing - including the check for clearing progress cache for monthly badges.

This PR fixes that and it adds helper function for generating monthly badge id, so it's done only in one place (thus hopefully eliminating this issue in the future).


## Summary

This PR can be summarized in the following changelog entry:

Fix generating inconsistent monthly badge ids

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
