### PR TITLE
Don't add links to "Update content" tasks when user doesn't have cap

### DIFF
--- a/classes/suggested-tasks/local-tasks/providers/class-content-update.php
+++ b/classes/suggested-tasks/local-tasks/providers/class-content-update.php
@@ -123,12 +123,12 @@ class Content_Update extends Content_Abstract {
 			'priority'    => 'high',
 			'type'        => 'writing',
 			'points'      => 1,
-			'url'         => \esc_url( \get_edit_post_link( $post->ID ) ), // @phpstan-ignore-line property.nonObject
+			'url'         => $this->capability_required() ? \esc_url( \get_edit_post_link( $post->ID ) ) : '', // @phpstan-ignore-line property.nonObject
 			'description' => '<p>' . sprintf(
 				/* translators: %s: The post title. */
 				\esc_html__( 'Update the post "%s" as it was last updated more than 6 months ago.', 'progress-planner' ),
 				\esc_html( $post->post_title ) // @phpstan-ignore-line property.nonObject
-			) . '</p><p><a href="' . \esc_url( \get_edit_post_link( $post->ID ) ) . '">' . \esc_html__( 'Edit the post', 'progress-planner' ) . '</a>.</p>', // @phpstan-ignore-line property.nonObject
+			) . '</p>' . ( $this->capability_required() ? '<p><a href="' . \esc_url( \get_edit_post_link( $post->ID ) ) . '">' . \esc_html__( 'Edit the post', 'progress-planner' ) . '</a>.</p>' : '' ), // @phpstan-ignore-line property.nonObject
 		];
 
 		return $task_details;

--- a/views/page-widgets/parts/monthly-badges.php
+++ b/views/page-widgets/parts/monthly-badges.php
@@ -34,9 +34,9 @@ $prpl_badges_year = (int) isset( $args['badges_year'] ) ? $args['badges_year'] :
 	<?php $prpl_badges = Monthly::get_instances_for_year( $prpl_badges_year ); ?>
 	<?php if ( $prpl_badges ) : ?>
 		<?php
-		$prpl_badges_per_row = 3;
-		$prpl_badges_count   = count( $prpl_badges );
-		$prpl_scroll_to_row  = 1;
+		$prpl_badges_per_row         = 3;
+		$prpl_badges_count           = count( $prpl_badges );
+		$prpl_scroll_to_row          = 1;
 		$prpl_current_month_badge_id = Monthly::get_badge_id_from_date( new \DateTime() );
 		if ( 'popover' !== $prpl_location ) {
 


### PR DESCRIPTION
## Context
This poppped out with the recent API endpoint change, notices where triggered.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

