### PR TITLE
Add lock while task is being added

### DIFF
--- a/classes/class-suggested-tasks-db.php
+++ b/classes/class-suggested-tasks-db.php
@@ -36,6 +36,17 @@ class Suggested_Tasks_DB {
 			return 0;
 		}
 
+		// Set lock transient.
+		$transient_key = 'prpl_task_lock_' . $data['task_id'];
+
+		// Check if the task is already being processed.
+		if ( \get_transient( $transient_key ) ) {
+			return 0;
+		}
+
+		// Set lock transient.
+		\set_transient( $transient_key, true, 5 );
+
 		// Check if we have an existing task with the same title.
 		$posts = $this->get_tasks_by(
 			[
@@ -53,6 +64,7 @@ class Suggested_Tasks_DB {
 
 		// If we have an existing task, skip.
 		if ( ! empty( $posts ) ) {
+			\delete_transient( $transient_key );
 			return $posts[0]->ID;
 		}
 
@@ -136,6 +148,8 @@ class Suggested_Tasks_DB {
 
 			\update_post_meta( $post_id, "prpl_$key", $value );
 		}
+
+		\delete_transient( $transient_key );
 
 		return $post_id;
 	}


### PR DESCRIPTION
There is an issue, more noticeable on slower hosing plans, when duplicated tasks are added. Most likely 2 processes / request get spawn in a very short timeframe (2nd one while the 1st one still hasn't inserted the task) and 2 same tasks get added.

This issue was reported by @tacoverdo , I have already implemented this fix on his site and so far there are no duplicates.