### PR TITLE
Preload tasks

### DIFF
--- a/assets/js/suggested-task.js
+++ b/assets/js/suggested-task.js
@@ -100,6 +100,32 @@ prplSuggestedTask = {
 			} ),
 
 	/**
+	 * Inject items.
+	 *
+	 * @param {Object[]} items The items to inject.
+	 */
+	injectItems: ( items ) => {
+		if ( items.length ) {
+			// Inject the items into the DOM.
+			items.forEach( ( item ) => {
+				document.dispatchEvent(
+					new CustomEvent( 'prpl/suggestedTask/injectItem', {
+						detail: {
+							item,
+							listId: 'prpl-suggested-tasks-list',
+							insertPosition: 'beforeend',
+						},
+					} )
+				);
+				prplSuggestedTask.injectedItemIds.push( item.id );
+			} );
+		}
+
+		// Trigger the grid resize event.
+		window.dispatchEvent( new CustomEvent( 'prpl/grid/resize' ) );
+	},
+
+	/**
 	 * Get a collection of posts.
 	 *
 	 * @param {Object} fetchArgs The arguments to pass to the fetch method.

--- a/assets/js/widgets/todo.js
+++ b/assets/js/widgets/todo.js
@@ -42,40 +42,70 @@ const prplTodoWidget = {
 	 * Populate the todo list.
 	 */
 	populateList: () => {
-		prplSuggestedTask
-			.fetchItems( {
-				category: 'user',
-				status: [ 'publish', 'trash' ],
-				per_page: 100,
-			} )
-			.then( ( data ) => {
-				if ( ! data.length ) {
+		// If preloaded tasks are available, inject them.
+		if ( 'undefined' !== typeof prplSuggestedTask.tasks ) {
+			// Inject the tasks.
+			if ( Object.keys( prplSuggestedTask.tasks.userTasks ).length ) {
+				Object.values( prplSuggestedTask.tasks.userTasks ).forEach(
+					( item ) => {
+						// Inject the items into the DOM.
+						document.dispatchEvent(
+							new CustomEvent( 'prpl/suggestedTask/injectItem', {
+								detail: {
+									item,
+									insertPosition:
+										1 === item?.meta?.prpl_points
+											? 'afterbegin' // Add golden task to the start of the list.
+											: 'beforeend',
+									listId:
+										item.status === 'publish'
+											? 'todo-list'
+											: 'todo-list-completed',
+								},
+							} )
+						);
+						prplSuggestedTask.injectedItemIds.push( item.id );
+					}
+				);
+				prplTodoWidget.removeLoadingItems();
+			}
+		} else {
+			// Otherwise, inject tasks from the API.
+			prplSuggestedTask
+				.fetchItems( {
+					category: 'user',
+					status: [ 'publish', 'trash' ],
+					per_page: 100,
+				} )
+				.then( ( data ) => {
+					if ( ! data.length ) {
+						return data;
+					}
+
+					// Inject the items into the DOM.
+					data.forEach( ( item ) => {
+						document.dispatchEvent(
+							new CustomEvent( 'prpl/suggestedTask/injectItem', {
+								detail: {
+									item,
+									insertPosition:
+										1 === item?.meta?.prpl_points
+											? 'afterbegin' // Add golden task to the start of the list.
+											: 'beforeend',
+									listId:
+										item.status === 'publish'
+											? 'todo-list'
+											: 'todo-list-completed',
+								},
+							} )
+						);
+						prplSuggestedTask.injectedItemIds.push( item.id );
+					} );
+
 					return data;
-				}
-
-				// Inject the items into the DOM.
-				data.forEach( ( item ) => {
-					document.dispatchEvent(
-						new CustomEvent( 'prpl/suggestedTask/injectItem', {
-							detail: {
-								item,
-								insertPosition:
-									1 === item?.meta?.prpl_points
-										? 'afterbegin' // Add golden task to the start of the list.
-										: 'beforeend',
-								listId:
-									item.status === 'publish'
-										? 'todo-list'
-										: 'todo-list-completed',
-							},
-						} )
-					);
-					prplSuggestedTask.injectedItemIds.push( item.id );
-				} );
-
-				return data;
-			} )
-			.then( () => prplTodoWidget.removeLoadingItems() );
+				} )
+				.then( () => prplTodoWidget.removeLoadingItems() );
+		}
 
 		// When the '#create-todo-item' form is submitted,
 		// add a new todo item to the list

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -9,6 +9,7 @@ namespace Progress_Planner;
 
 use Progress_Planner\Activities\Suggested_Task as Suggested_Task_Activity;
 use Progress_Planner\Suggested_Tasks\Tasks_Manager;
+use Progress_Planner\Suggested_Tasks\Providers\Content_Review;
 
 /**
  * Recommendations class.
@@ -439,5 +440,91 @@ class Suggested_Tasks {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Get the pending tasks in REST format.
+	 *
+	 * @param array $args The arguments.
+	 *
+	 * @return array
+	 */
+	public function get_tasks_in_rest_format( array $args = [] ) {
+		$args = wp_parse_args(
+			$args,
+			[
+				'post_status'      => 'publish',
+				'exclude_provider' => [],
+				'include_provider' => [],
+			]
+		);
+
+		// Get the max items per category.
+		$max_items_per_category = $this->get_max_items_per_category();
+
+		// Initialize the tasks array.
+		$tasks = [];
+
+		// Get the tasks for each category.
+		foreach ( $max_items_per_category as $category_slug => $max_items ) {
+
+			// Skip excluded providers.
+			if ( ! empty( $args['exclude_provider'] ) && in_array( $category_slug, $args['exclude_provider'], true ) ) {
+				continue;
+			}
+
+			// Skip not included providers.
+			if ( ! empty( $args['include_provider'] ) && ! in_array( $category_slug, $args['include_provider'], true ) ) {
+				continue;
+			}
+
+			$category_tasks = \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+				[
+					'category'       => $category_slug,
+					'posts_per_page' => $max_items,
+					'post_status'    => $args['post_status'],
+				]
+			);
+
+			if ( ! empty( $category_tasks ) ) {
+				$tasks[ $category_slug ] = [];
+
+				foreach ( $category_tasks as $task ) {
+					$tasks[ $category_slug ][] = $task->get_rest_formatted_data();
+				}
+			}
+		}
+
+		return $tasks;
+	}
+
+	/**
+	 * Get the max items per category.
+	 *
+	 * @return array
+	 */
+	public function get_max_items_per_category() {
+		// Set max items per category.
+		$max_items_per_category = [];
+		$provider_categories    = \get_terms(
+			[
+				'taxonomy'   => 'prpl_recommendations_category',
+				'hide_empty' => false,
+			]
+		);
+
+		if ( ! empty( $provider_categories ) && ! is_wp_error( $provider_categories ) ) {
+			$content_review_category = ( new Content_Review() )->get_provider_category();
+			foreach ( $provider_categories as $provider_category ) {
+				$max_items_per_category[ $provider_category->slug ] = $provider_category->slug === $content_review_category ? 2 : 1;
+			}
+		}
+
+		// This should never happen, but just in case - user tasks are displayed in different widget.
+		if ( isset( $max_items_per_category['user'] ) ) {
+			$max_items_per_category['user'] = 100;
+		}
+
+		return apply_filters( 'progress_planner_suggested_tasks_max_items_per_category', $max_items_per_category );
 	}
 }

--- a/views/js-templates/suggested-task.html
+++ b/views/js-templates/suggested-task.html
@@ -14,7 +14,7 @@
 				</prpl-tooltip>
 			<# } else { #>
 				<label>
-					<input type="checkbox" class="prpl-suggested-task-checkbox" onchange="prplSuggestedTask.maybeComplete( {{ data.post.id }} );" style="margin-top: 2px; pointer-events: none;" <# if ( ! data.post.meta.prpl_dismissable || 'trash' === data.post.status || 'pending' === data.post.status ) { #>disabled<# } #> <# if ( 'trash' === data.post.status || 'pending' === data.post.status ) { #>checked<# } #>>
+					<input type="checkbox" class="prpl-suggested-task-checkbox" onchange="prplSuggestedTask.maybeComplete( {{ data.post.id }} );" style="margin-top: 2px; pointer-events: none;" <# if ( ! data.post.meta.prpl_dismissable || 'user' !== categorySlug && ( 'trash' === data.post.status || 'pending' === data.post.status ) ) { #>disabled<# } #> <# if ( 'trash' === data.post.status || 'pending' === data.post.status ) { #>checked<# } #>>
 					<span class="screen-reader-text">{{{ data.post.title.rendered }}}: {{ data.l10n.markAsComplete }}</span>
 				</label>
 			<# } #>


### PR DESCRIPTION
On slower hosting plans API request can take a bit longer, so it takes some time until tasks widgets are populated on page load.

This PR tries to improve user experience by preloading tasks, they are now generated server side and assigned to JS global var. Our logic is adjusted to inject tasks from there.

I haven't removed the old way of injecting tasks, just in case, all that it needs to be done to re-activate it is to comment out these [lines](https://github.com/Emilia-Capital/progress-planner/blob/f84d0020394b2f0cbbbe147d2c376b9c2d6cf940/classes/admin/class-enqueue.php#L239-L243).