### PR TITLE
Fix missing pages (page types) from the Settings screen

### DIFF
--- a/classes/class-page-types.php
+++ b/classes/class-page-types.php
@@ -17,7 +17,7 @@ class Page_Types {
 	 *
 	 * @var array
 	 */
-	public static $page_types = [];
+	public static $page_types = null;
 
 	/**
 	 * The taxonomy name.


### PR DESCRIPTION
The pages were missing since the condition [here](https://github.com/Emilia-Capital/progress-planner/blob/4e5880b444a0303248a23cace58becd58fb7075c/classes/class-page-types.php#L155-L157) was always met.

The bug was introduced in [this commit](https://github.com/ProgressPlanner/progress-planner/commit/02b660e15f86e394b800712d688fb301e233a38f#diff-9dd1a1a855c98851d1d2c9b6dd0c066f6a0b961fc89fe3415ce7b45bc8b69c7d).