### PR TITLE
Clear WP API model schema

### DIFF
--- a/classes/admin/class-enqueue.php
+++ b/classes/admin/class-enqueue.php
@@ -48,6 +48,15 @@ class Enqueue {
 	];
 
 	/**
+	 * Init.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		\add_action( 'admin_head', [ $this, 'maybe_empty_session_storage' ], 1 );
+	}
+
+	/**
 	 * Enqueue script.
 	 *
 	 * @param string $handle        The handle of the script to enqueue.
@@ -392,5 +401,44 @@ class Enqueue {
 			'activated'                    => \esc_html__( 'Activated', 'progress-planner' ),
 			'activateFailed'               => \esc_html__( 'Activation failed', 'progress-planner' ),
 		];
+	}
+
+	/**
+	 * Maybe empty the session storage for the prpl_recommendations post type.
+	 * We need to do it early, before the WP API script reads the cached data from the browser.
+	 *
+	 * @return void
+	 */
+	public function maybe_empty_session_storage() {
+		$screen = get_current_screen();
+
+		if ( ! $screen ) {
+			return;
+		}
+
+		// Inject the script only on the Progress Planner Dashboard, Progress Planner Settings and the WordPress dashboard pages.
+		if ( 'toplevel_page_progress-planner' !== $screen->id && 'progress-planner_page_progress-planner-settings' !== $screen->id && 'dashboard' !== $screen->id ) {
+			return;
+		}
+		?>
+		<script type="text/javascript">
+			if ( 'sessionStorage' in window ) {
+				try {
+					for ( const key in sessionStorage ) {
+						if ( -1 < key.indexOf( 'wp-api-schema-model' ) ) {
+							const item = sessionStorage.getItem( key );
+							if (
+								-1 === item.indexOf( '/wp/v2/prpl_recommendations' )
+							) {
+								sessionStorage.removeItem( key );
+
+								break;
+							}
+						}
+					}
+				} catch ( er ) {}
+			}
+		</script>
+		<?php
 	}
 }

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -155,6 +155,9 @@ class Base {
 			$this->get_wp_cli__get_stats_command();
 			$this->get_wp_cli__task_command();
 		}
+
+		// Init the enqueue class.
+		$this->get_admin__enqueue()->init();
 	}
 
 	/**


### PR DESCRIPTION
WP uses [browser session storage](https://github.com/WordPress/WordPress/blob/master/wp-includes/js/wp-api.js#L1161-L1201) to cache it's API model schema. We have a problem since we are registering custom post types and taxonomies and their endpoints will be missing from the cached schema, until the user closes (and re-opens) the browser.

For our Recommendations widget to work properly we need to clear session storage on the pages on which that widget is used, PP Dashboard and WP Dashboard pages - but we need to do it before the WP api is inited and cached value is read from the browser.

That is why we add inline script in the `admin_head` hook, since by the time our scripts are loaded cached value is already read and the JS error will be triggered on first page load.

This is the least invasive method I could come up with, only that one storage key is removed and only if one of our endpoints is not there.