### PR TITLE
Make interactive tasks work on WP dashboard screen

### DIFF
--- a/assets/js/recommendations/core-blogdescription.js
+++ b/assets/js/recommendations/core-blogdescription.js
@@ -15,7 +15,7 @@ prplInteractiveTaskFormListener.siteSettings( {
 
 document
 	.querySelector( 'input#blogdescription' )
-	.addEventListener( 'input', function ( e ) {
+	?.addEventListener( 'input', function ( e ) {
 		const button = document.querySelector(
 			'[popover-id="prpl-popover-core-blogdescription"] button[type="submit"]'
 		);

--- a/classes/suggested-tasks/providers/class-tasks-interactive.php
+++ b/classes/suggested-tasks/providers/class-tasks-interactive.php
@@ -26,6 +26,7 @@ abstract class Tasks_Interactive extends Tasks {
 	 */
 	public function __construct() {
 		\add_action( 'progress_planner_admin_page_after_widgets', [ $this, 'add_popover' ] );
+		\add_action( 'progress_planner_admin_dashboard_widget_score_after', [ $this, 'add_popover' ] );
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 		\add_action( 'wp_ajax_prpl_interactive_task_submit', [ $this, 'handle_interactive_task_submit' ] );
 	}

--- a/views/dashboard-widgets/score.php
+++ b/views/dashboard-widgets/score.php
@@ -75,3 +75,12 @@ use Progress_Planner\Badges\Monthly;
 		</div>
 	</div>
 <?php endif; ?>
+
+<?php
+	/**
+	 * Fires after the score widget is rendered.
+	 *
+	 * @since 1.7.1
+	 */
+	\do_action( 'progress_planner_admin_dashboard_widget_score_after' );
+?>


### PR DESCRIPTION
The action which we use to inject popover content was only triggered on PP Dashboard screen, so popovers weren't available on WP Dashboard screen.

This PR adds a new `do_action` on WP Dashboard screen.