### PR TITLE
Exclude 'gblocks_pattern_collections' taxonomy terms from "Remove term" task

### DIFF
--- a/classes/suggested-tasks/data-collector/class-terms-without-posts.php
+++ b/classes/suggested-tasks/data-collector/class-terms-without-posts.php
@@ -105,6 +105,7 @@ class Terms_Without_Posts extends Base_Data_Collector {
 				'product_shipping_class',
 				'prpl_recommendations_category',
 				'prpl_recommendations_provider',
+				'gblocks_pattern_collections',
 			]
 		);
 


### PR DESCRIPTION
These terms were added by `GenerateBlocks` plugin and can't be removed.