### PR TITLE
Improve check for "Unpublished content" task

### DIFF
--- a/classes/suggested-tasks/providers/class-unpublished-content.php
+++ b/classes/suggested-tasks/providers/class-unpublished-content.php
@@ -355,7 +355,13 @@ class Unpublished_Content extends Tasks {
 
 		$data = $task->get_data();
 
-		return $data && isset( $data['target_post_id'] )
-			&& 'publish' === \get_post_status( $data['target_post_id'] );
+		if ( ! $data || ! isset( $data['target_post_id'] ) ) {
+			return false;
+		}
+
+		$post_status = \get_post_status( $data['target_post_id'] );
+
+		// If the post status is publish, trash or false (post was deleted), the task is completed.
+		return ( 'publish' === $post_status || 'trash' === $post_status || false === $post_status );
 	}
 }


### PR DESCRIPTION
Until now point was awarded only if the post was published, this PR makes a change so point is awarded (and task completed) if post is trashed or completely deleted as well.