### PR TITLE
Put back onboard background

### DIFF
--- a/assets/css/welcome.css
+++ b/assets/css/welcome.css
@@ -1,5 +1,8 @@
 .prpl-wrap.prpl-pp-not-accepted {
 	padding: 0;
+	background-color: #fff;
+	border: 1px solid var(--prpl-color-gray-2);
+	border-radius: var(--prpl-border-radius);
 }
 
 .prpl-welcome {


### PR DESCRIPTION
In https://github.com/ProgressPlanner/progress-planner/pull/588 we changed the background for all pages, but that also removes the white background from the Onboard wrapper (which doesnt look nice).

This PR puts it back.