### PR TITLE
Previous month points are not decreased when golden task is set back to pending

### DIFF
--- a/assets/js/web-components/prpl-badge-progress-bar.js
+++ b/assets/js/web-components/prpl-badge-progress-bar.js
@@ -113,10 +113,8 @@ const prplUpdatePreviousMonthBadgeProgressBar = ( pointsDiff ) => {
 	);
 
 	if ( remainingPointsEl ) {
-		remainingPointsEl.textContent = remainingPointsEl.textContent.replace(
-			remainingPointsEl.getAttribute( 'data-remaining' ),
-			badgeMaxPoints - badgeNewPoints
-		);
+		// The points in the remaining points element are updated in the prplUpdatePreviousMonthBadgeCounters function.
+
 		remainingPointsEl.setAttribute(
 			'data-remaining',
 			badgeMaxPoints - badgeNewPoints


### PR DESCRIPTION
Fixes #621

The problem was that the `span.number` element was removed after the first update, which then prevented [this code](https://github.com/Emilia-Capital/progress-planner/blob/f783dcab3ab1cd21dade374403638f47953b7d9a/assets/js/web-components/prpl-badge-progress-bar.js#L192-L195) to update it again