### PR TITLE
Correct CSS color var name

### DIFF
--- a/assets/css/page-widgets/suggested-tasks.css
+++ b/assets/css/page-widgets/suggested-tasks.css
@@ -154,7 +154,7 @@
 		&.prpl-column-content {
 			padding: 20px;
 			border-radius: var(--prpl-border-radius-big);
-			background-color: var(--background-content);
+			background-color: var(--prpl-background-content);
 		}
 
 		.prpl-note {

--- a/assets/css/variables-color.css
+++ b/assets/css/variables-color.css
@@ -93,4 +93,7 @@
 	--prpl-color-text-placeholder: var(--prpl-color-ui-icon);
 	--prpl-color-text-dropdown: var(--prpl-color-text);
 	--prpl-color-field-shadow: var(--prpl-color-shadow-paper);
+
+	/* Badge */
+	--prpl-color-icon-missed-badge: var(--prpl-color-alert-error);
 }

--- a/assets/css/web-components/prpl-badge.css
+++ b/assets/css/web-components/prpl-badge.css
@@ -76,7 +76,7 @@ prpl-badge {
 			justify-content: center;
 			width: 20px;
 			height: 20px;
-			background-color: var(--prpl-color-alert-error);
+			background-color: var(--prpl-color-icon-missed-badge);
 			border: 2px solid #fff;
 			border-radius: 50%;
 			position: absolute;

--- a/assets/js/web-components/prpl-big-counter.js
+++ b/assets/js/web-components/prpl-big-counter.js
@@ -13,7 +13,8 @@ customElements.define(
 			content = content || this.getAttribute( 'content' );
 			backgroundColor =
 				backgroundColor || this.getAttribute( 'background-color' );
-			backgroundColor = backgroundColor || 'var(--background-content)';
+			backgroundColor =
+				backgroundColor || 'var(--prpl-background-content)';
 
 			const el = this;
 

--- a/views/page-widgets/content-activity.php
+++ b/views/page-widgets/content-activity.php
@@ -96,7 +96,7 @@ foreach ( \array_keys( $prpl_activity_types ) as $prpl_activity_type ) {
 <prpl-big-counter
 	number="<?php echo \esc_html( \number_format_i18n( (int) $prpl_activities_count['all'] ) ); ?>"
 	content="<?php \esc_attr_e( 'pieces of content managed', 'progress-planner' ); ?>"
-	background-color="var(--background-content)"
+	background-color="var(--prpl-background-content)"
 ></prpl-big-counter>
 
 <div class="prpl-graph-wrapper">


### PR DESCRIPTION
This PR corrects CSS color variable name per https://github.com/ProgressPlanner/progress-planner-pro/issues/157#issuecomment-3365524491 and adds new color for missed badge icon