### PR TITLE
Dont enqueue scripts on WP Dashboard page for user who dont get our widgets

### DIFF
--- a/classes/suggested-tasks/providers/class-tasks-interactive.php
+++ b/classes/suggested-tasks/providers/class-tasks-interactive.php
@@ -162,6 +162,12 @@ abstract class Tasks_Interactive extends Tasks {
 	 * @return void
 	 */
 	public function enqueue_scripts( $hook ) {
+
+		// Don't enqueue the script if the user is not at least an editor, since we dont want to enqueue scripts on WP Dashboard page.
+		if ( ! \current_user_can( 'edit_others_posts' ) ) {
+			return;
+		}
+
 		// Enqueue the script only on Progress Planner and WP dashboard pages.
 		if ( 'toplevel_page_progress-planner' !== $hook && 'index.php' !== $hook ) {
 			return;


### PR DESCRIPTION
We dont display widgets on WP Dashboard page for users with lower role than Editor and we properly dont init related widget classes in that case.

But we init task providers and interactive task providers do enqueue scripts on their own. There is a check on which page they are enqueued, but they are missing the capability check.

This PR adds a check for that, so there are no scripts (and localized data) added to the WP Dashboard page in case that is not needed.