### PR TITLE
Detect site logo as fallback, for "Yoast SEO: set your organization logo" task

### DIFF
--- a/classes/suggested-tasks/providers/integrations/yoast/class-organization-logo.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-organization-logo.php
@@ -107,7 +107,7 @@ class Organization_Logo extends Yoast_Provider {
 
 		// If the site logo is set, we don't need to add the task.
 		if ( (int) $site_logo_id ) {
-			return true;
+			return false;
 		}
 
 		// If the site is for a person, and the person logo is already set, we don't need to add the task.

--- a/classes/suggested-tasks/providers/integrations/yoast/class-organization-logo.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-organization-logo.php
@@ -98,6 +98,18 @@ class Organization_Logo extends Yoast_Provider {
 	 * @return bool
 	 */
 	public function should_add_task() {
+
+		// Check if the site logo is set, Yoast SEO uses it as a fallback.
+		$site_logo_id = \get_option( 'site_logo' );
+		if ( ! $site_logo_id ) {
+			$site_logo_id = \get_theme_mod( 'custom_logo', false );
+		}
+
+		// If the site logo is set, we don't need to add the task.
+		if ( (int) $site_logo_id ) {
+			return true;
+		}
+
 		// If the site is for a person, and the person logo is already set, we don't need to add the task.
 		if ( $this->yoast_seo->helpers->options->get( 'company_or_person', 'company' ) === 'company' // @phpstan-ignore-line property.nonObject
 			&& $this->yoast_seo->helpers->options->get( 'company_logo' ) // @phpstan-ignore-line property.nonObject

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,12 @@ https://youtu.be/e1bmxZYyXFY
 
 == Changelog ==
 
+= 1.9.0 =
+
+Enhancements:
+
+* "Yoast SEO: set your organization logo" task detects site logo as fallback, same as Yoast SEO does.
+
 = 1.8.1 =
 
 - Security fix: Privilege escalation via an AJAX call where authenticated users could update arbitrary site options.


### PR DESCRIPTION
Yoast SEO detects if site logo is set and uses it as fallback image for "Person" or "Organization" logo.

This PR updates the "Yoast SEO: set your organization logo" task to do the same - task will not be added if the site logo is set.

If it's not set, checks will work as they worked before - based on user selection it is checked if organization or person logo are set.