### PR TITLE
Add color2 attribute to gauges

### DIFF
--- a/assets/js/web-components/prpl-gauge.js
+++ b/assets/js/web-components/prpl-gauge.js
@@ -24,6 +24,7 @@ customElements.define(
 				'maxdeg',
 				'background',
 				'color',
+				'color2',
 				'start',
 				'cutout',
 				'contentfontsize',

--- a/views/dashboard-widgets/score.php
+++ b/views/dashboard-widgets/score.php
@@ -37,6 +37,7 @@ $prpl_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( ne
 		<prpl-gauge
 			background="#fff"
 			color="<?php echo \esc_attr( \progress_planner()->get_admin__widgets__activity_scores()->get_gauge_color( \progress_planner()->get_admin__widgets__activity_scores()->get_score() ) ); ?>"
+			color2="<?php echo \esc_attr( \progress_planner()->get_admin__widgets__activity_scores()->get_gauge_color( \progress_planner()->get_admin__widgets__activity_scores()->get_score() ) ); ?>"
 			contentFontSize="var(--prpl-font-size-5xl)"
 			contentPadding="var(--prpl-padding)"
 			marginBottom="0"

--- a/views/page-widgets/activity-scores.php
+++ b/views/page-widgets/activity-scores.php
@@ -42,6 +42,7 @@ $prpl_record = $prpl_widget->personal_record_callback();
 	<prpl-gauge
 		background="var(--prpl-background-activity)"
 		color="<?php echo \esc_attr( $prpl_widget->get_gauge_color( $prpl_widget->get_score() ) ); ?>"
+		color2="<?php echo \esc_attr( $prpl_widget->get_gauge_color( $prpl_widget->get_score() ) ); ?>"
 		contentFontSize="var(--prpl-font-size-6xl)"
 		data-max="100"
 		data-value="<?php echo (float) $prpl_widget->get_score(); ?>"


### PR DESCRIPTION
In https://github.com/ProgressPlanner/progress-planner/pull/660 we have added `color2` attribute in order to make gradient gauges possible.

The default value was set to default value of the new `color2` CSS variable, but there are gauges (like activity) which use different color.

This PR fixes that by adding `color2` attribute, so both attributes can be changed for every gauge specifically.