### PR TITLE
Fix missing JS global variable on WP Dashboard page

### DIFF
--- a/assets/js/web-components/prpl-install-plugin.js
+++ b/assets/js/web-components/prpl-install-plugin.js
@@ -1,4 +1,4 @@
-/* global customElements, HTMLElement, prplL10n, progressPlanner, progressPlannerAjaxRequest, prplSuggestedTask */
+/* global customElements, HTMLElement, prplL10n, progressPlannerAjaxRequest, prplSuggestedTask */
 /*
  * Install Plugin
  *
@@ -81,12 +81,12 @@ customElements.define(
 			`;
 
 			progressPlannerAjaxRequest( {
-				url: progressPlanner.ajaxUrl,
+				url: this.getAjaxUrl(),
 				data: {
 					action: 'progress_planner_install_plugin',
 					plugin_slug: this.pluginSlug,
 					plugin_name: this.pluginName,
-					nonce: progressPlanner.nonce,
+					nonce: this.getNonce(),
 				},
 			} )
 				.then( () => thisObj.activatePlugin() )
@@ -102,12 +102,12 @@ customElements.define(
 			`;
 
 			progressPlannerAjaxRequest( {
-				url: progressPlanner.ajaxUrl,
+				url: this.getAjaxUrl(),
 				data: {
 					action: 'progress_planner_activate_plugin',
 					plugin_slug: thisObj.pluginSlug,
 					plugin_name: thisObj.pluginName,
-					nonce: progressPlanner.nonce,
+					nonce: this.getNonce(),
 				},
 			} )
 				.then( () => {
@@ -140,6 +140,26 @@ customElements.define(
 					}
 				}
 			} );
+		}
+
+		/**
+		 * Get the AJAX URL.
+		 *
+		 * @return {string} The AJAX URL.
+		 */
+		getAjaxUrl() {
+			return window.progressPlanner?.ajaxUrl ?? window.ajaxurl;
+		}
+
+		/**
+		 * Get the nonce.
+		 *
+		 * @return {string} The nonce.
+		 */
+		getNonce() {
+			return (
+				window.progressPlanner?.nonce ?? window.prplSuggestedTask?.nonce
+			);
 		}
 	}
 );


### PR DESCRIPTION
Activating plugin, from `prpl-install-plugin` component, was failing due to the global `progressPlanner` variable missing on the WP Dashboard page.

This PR adds a fallback for the missing data in least invasive way. Ideally we should add this data as localized data for the `prpl-install-plugin` script.