### PR TITLE
Remove "Recommendations UI" from Playground

### DIFF
--- a/classes/utils/class-debug-tools.php
+++ b/classes/utils/class-debug-tools.php
@@ -47,12 +47,15 @@ class Debug_Tools {
 		\add_action( 'init', [ $this, 'check_delete_badges' ] );
 		\add_action( 'init', [ $this, 'check_toggle_migrations' ] );
 		\add_action( 'init', [ $this, 'check_delete_single_task' ] );
+		\add_action( 'init', [ $this, 'check_toggle_recommendations_ui' ] );
 		if ( \defined( '\IS_PLAYGROUND_PREVIEW' ) && \constant( '\IS_PLAYGROUND_PREVIEW' ) === true ) {
 			\add_action( 'init', [ $this, 'check_toggle_placeholder_demo' ] );
 		}
 
 		// Initialize color customizer.
 		$this->get_color_customizer();
+
+		\add_filter( 'progress_planner_tasks_show_ui', [ $this, 'filter_tasks_show_ui' ] );
 	}
 
 	/**
@@ -85,6 +88,8 @@ class Debug_Tools {
 		$this->add_more_info_submenu_item( $admin_bar );
 
 		$this->add_toggle_migrations_submenu_item( $admin_bar );
+
+		$this->add_toggle_recommendations_ui_submenu_item( $admin_bar );
 
 		// Add color customizer item.
 		$admin_bar->add_node(
@@ -320,6 +325,27 @@ class Debug_Tools {
 	}
 
 	/**
+	 * Add Toggle Recommendations UI submenu to the debug menu.
+	 *
+	 * @param \WP_Admin_Bar $admin_bar The WordPress admin bar object.
+	 * @return void
+	 */
+	protected function add_toggle_recommendations_ui_submenu_item( $admin_bar ) {
+		$debug_enabled = \get_option( 'prpl_debug_recommendations_ui', false );
+		$title         = $debug_enabled ? '<span style="color: green;">Recommendations UI Enabled</span>' : '<span style="color: red;">Recommendations UI Disabled</span>';
+		$href          = \add_query_arg( 'prpl_toggle_recommendations_ui', '1', $this->current_url );
+
+		$admin_bar->add_node(
+			[
+				'id'     => 'prpl-toggle-recommendations-ui',
+				'parent' => 'prpl-debug',
+				'title'  => $title,
+				'href'   => $href,
+			]
+		);
+	}
+
+	/**
 	 * Check and process the toggle migrations action.
 	 *
 	 * Toggles the debug option if the appropriate query parameter is set
@@ -349,6 +375,39 @@ class Debug_Tools {
 
 		// Redirect to the same page without the parameter.
 		\wp_safe_redirect( \remove_query_arg( [ 'prpl_toggle_migrations', '_wpnonce' ] ) );
+		exit;
+	}
+
+	/**
+	 * Check and process the toggle recommendations UI action.
+	 *
+	 * Toggles the debug option if the appropriate query parameter is set
+	 * and user has required capabilities.
+	 *
+	 * @return void
+	 */
+	public function check_toggle_recommendations_ui() {
+		if (
+			! isset( $_GET['prpl_toggle_recommendations_ui'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$_GET['prpl_toggle_recommendations_ui'] !== '1' || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			! \current_user_can( 'manage_options' )
+		) {
+			return;
+		}
+
+		// Verify nonce for security.
+		$this->verify_nonce();
+
+		// Toggle the debug option.
+		$current_value = \get_option( 'prpl_debug_recommendations_ui', false );
+		if ( $current_value ) {
+			\delete_option( 'prpl_debug_recommendations_ui' );
+		} else {
+			\update_option( 'prpl_debug_recommendations_ui', true );
+		}
+
+		// Redirect to the same page without the parameter.
+		\wp_safe_redirect( \remove_query_arg( [ 'prpl_toggle_recommendations_ui', '_wpnonce' ] ) );
 		exit;
 	}
 
@@ -670,5 +729,18 @@ class Debug_Tools {
 			$color_customizer = new Color_Customizer();
 		}
 		return $color_customizer;
+	}
+
+	/**
+	 * Filter the tasks show UI.
+	 *
+	 * @param bool $show_ui The show UI.
+	 * @return bool
+	 */
+	public function filter_tasks_show_ui( $show_ui ) {
+		if ( \get_option( 'prpl_debug_recommendations_ui', false ) ) {
+			return true;
+		}
+		return $show_ui;
 	}
 }

--- a/classes/utils/class-playground.php
+++ b/classes/utils/class-playground.php
@@ -18,7 +18,6 @@ class Playground {
 	public function __construct() {
 		\add_action( 'init', [ $this, 'register_hooks' ], 9 );
 		\add_action( 'plugins_loaded', [ $this, 'enable_debug_tools' ], 1 );
-		\add_filter( 'progress_planner_tasks_show_ui', '__return_true' );
 		\add_action( 'admin_footer', [ $this, 'inject_playground_js_patch' ] );
 		\add_action( 'init', [ $this, 'disable_upgrade_tasks_popover' ], 101 );
 	}


### PR DESCRIPTION
This PR removes filter which makes the Recommendations UI visible by default from Playground and adds the Toggle button the Debug tools (as it still might be useful to show it sometimes).