### PR TITLE
Fix JS errors when popover for updating / deleting terms is not in the DOM

### DIFF
--- a/assets/js/recommendations/remove-terms-without-posts.js
+++ b/assets/js/recommendations/remove-terms-without-posts.js
@@ -14,6 +14,12 @@
 		 */
 		constructor() {
 			this.popoverId = 'prpl-popover-remove-terms-without-posts';
+
+			// Early return if the popover is not found.
+			if ( ! document.getElementById( this.popoverId ) ) {
+				return;
+			}
+
 			this.currentTermData = null;
 			this.currentTaskElement = null;
 			this.elements = this.getElements();

--- a/assets/js/recommendations/update-term-description.js
+++ b/assets/js/recommendations/update-term-description.js
@@ -14,6 +14,12 @@
 		 */
 		constructor() {
 			this.popoverId = 'prpl-popover-update-term-description';
+
+			// Early return if the popover is not found.
+			if ( ! document.getElementById( this.popoverId ) ) {
+				return;
+			}
+
 			this.currentTermData = null;
 			this.currentTaskElement = null;
 			this.elements = this.getElements();


### PR DESCRIPTION
This PR adds an early exit to the JavaScript logic for "update term description" and "delete term without posts" interactive tasks.

Something which happens relatively open, we load all JS files regardless if the the task is actually created or not - so might need to find a general solution for the next release.