### PR TITLE
v1.9 dev - Fix interactive tasks

### DIFF
--- a/assets/js/recommendations/aioseo-author-archive.js
+++ b/assets/js/recommendations/aioseo-author-archive.js
@@ -10,15 +10,23 @@ prplInteractiveTaskFormListener.customSubmit( {
 	taskId: 'aioseo-author-archive',
 	popoverId: 'prpl-popover-aioseo-author-archive',
 	callback: () => {
-		fetch( progressPlanner.ajaxUrl, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-			body: new URLSearchParams( {
-				action: 'prpl_interactive_task_submit_aioseo-author-archive',
-				nonce: progressPlanner.nonce,
-			} ),
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_aioseo-author-archive',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
 		} );
 	},
 } );

--- a/assets/js/recommendations/aioseo-crawl-settings-feed-authors.js
+++ b/assets/js/recommendations/aioseo-crawl-settings-feed-authors.js
@@ -10,15 +10,23 @@ prplInteractiveTaskFormListener.customSubmit( {
 	taskId: 'aioseo-crawl-settings-feed-authors',
 	popoverId: 'prpl-popover-aioseo-crawl-settings-feed-authors',
 	callback: () => {
-		fetch( progressPlanner.ajaxUrl, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-			body: new URLSearchParams( {
-				action: 'prpl_interactive_task_submit_aioseo-crawl-settings-feed-authors',
-				nonce: progressPlanner.nonce,
-			} ),
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_aioseo-crawl-settings-feed-authors',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
 		} );
 	},
 } );

--- a/assets/js/recommendations/aioseo-crawl-settings-feed-comments.js
+++ b/assets/js/recommendations/aioseo-crawl-settings-feed-comments.js
@@ -10,15 +10,23 @@ prplInteractiveTaskFormListener.customSubmit( {
 	taskId: 'aioseo-crawl-settings-feed-comments',
 	popoverId: 'prpl-popover-aioseo-crawl-settings-feed-comments',
 	callback: () => {
-		fetch( progressPlanner.ajaxUrl, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-			body: new URLSearchParams( {
-				action: 'prpl_interactive_task_submit_aioseo-crawl-settings-feed-comments',
-				nonce: progressPlanner.nonce,
-			} ),
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_aioseo-crawl-settings-feed-comments',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
 		} );
 	},
 } );

--- a/assets/js/recommendations/aioseo-date-archive.js
+++ b/assets/js/recommendations/aioseo-date-archive.js
@@ -10,15 +10,23 @@ prplInteractiveTaskFormListener.customSubmit( {
 	taskId: 'aioseo-date-archive',
 	popoverId: 'prpl-popover-aioseo-date-archive',
 	callback: () => {
-		fetch( progressPlanner.ajaxUrl, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-			body: new URLSearchParams( {
-				action: 'prpl_interactive_task_submit_aioseo-date-archive',
-				nonce: progressPlanner.nonce,
-			} ),
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_aioseo-date-archive',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
 		} );
 	},
 } );

--- a/assets/js/recommendations/aioseo-media-pages.js
+++ b/assets/js/recommendations/aioseo-media-pages.js
@@ -10,15 +10,23 @@ prplInteractiveTaskFormListener.customSubmit( {
 	taskId: 'aioseo-media-pages',
 	popoverId: 'prpl-popover-aioseo-media-pages',
 	callback: () => {
-		fetch( progressPlanner.ajaxUrl, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-			body: new URLSearchParams( {
-				action: 'prpl_interactive_task_submit_aioseo-media-pages',
-				nonce: progressPlanner.nonce,
-			} ),
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_aioseo-media-pages',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
 		} );
 	},
 } );

--- a/assets/js/recommendations/core-permalink-structure.js
+++ b/assets/js/recommendations/core-permalink-structure.js
@@ -14,16 +14,24 @@ prplInteractiveTaskFormListener.customSubmit( {
 			'#prpl-popover-core-permalink-structure input[name="prpl_custom_permalink_structure"]'
 		);
 
-		fetch( progressPlanner.ajaxUrl, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-			body: new URLSearchParams( {
-				action: 'prpl_interactive_task_submit_core-permalink-structure',
-				nonce: progressPlanner.nonce,
-				value: customPermalinkStructure.value,
-			} ),
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_core-permalink-structure',
+					nonce: progressPlanner.nonce,
+					value: customPermalinkStructure.value,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
 		} );
 	},
 } );

--- a/assets/js/recommendations/interactive-task.js
+++ b/assets/js/recommendations/interactive-task.js
@@ -51,12 +51,6 @@ const prplInteractiveTaskFormListener = {
 				const settings = new wp.api.models.Settings( settingsToPass );
 
 				settings.save().then( ( response ) => {
-					console.log( response );
-					if ( true !== response.success ) {
-						// TODO: Handle error.
-						return response;
-					}
-
 					const postId = parseInt( taskEl.dataset.postId );
 					if ( ! postId ) {
 						return response;
@@ -97,7 +91,6 @@ const prplInteractiveTaskFormListener = {
 					const taskEl = document.querySelector(
 						`.prpl-suggested-task[data-task-id="${ taskId }"]`
 					);
-
 					const postId = parseInt( taskEl.dataset.postId );
 					if ( ! postId ) {
 						return;

--- a/assets/js/recommendations/remove-terms-without-posts.js
+++ b/assets/js/recommendations/remove-terms-without-posts.js
@@ -143,20 +143,30 @@
 				taskId: this.currentTaskElement.dataset.taskId,
 				popoverId: this.popoverId,
 				callback: () => {
-					fetch( progressPlanner.ajaxUrl, {
-						method: 'POST',
-						headers: {
-							'Content-Type': 'application/x-www-form-urlencoded',
-						},
-						body: new URLSearchParams( {
-							action: 'prpl_interactive_task_submit_remove-terms-without-posts',
-							nonce: progressPlanner.nonce,
-							term_id: this.elements.termIdField.value,
-							taxonomy: this.elements.taxonomyField.value,
-						} ),
-					} ).then( () => {
-						this.currentTaskElement = null;
-						this.currentTermData = null;
+					return new Promise( ( resolve, reject ) => {
+						fetch( progressPlanner.ajaxUrl, {
+							method: 'POST',
+							headers: {
+								'Content-Type':
+									'application/x-www-form-urlencoded',
+							},
+							body: new URLSearchParams( {
+								action: 'prpl_interactive_task_submit_remove-terms-without-posts',
+								nonce: progressPlanner.nonce,
+								term_id: this.elements.termIdField.value,
+								taxonomy: this.elements.taxonomyField.value,
+							} ),
+						} )
+							.then( () => {
+								this.currentTaskElement = null;
+								this.currentTermData = null;
+							} )
+							.then( ( response ) => {
+								resolve( { response, success: true } );
+							} )
+							.catch( ( error ) => {
+								reject( { success: false, error } );
+							} );
 					} );
 				},
 			} );

--- a/assets/js/recommendations/rename-uncategorized-category.js
+++ b/assets/js/recommendations/rename-uncategorized-category.js
@@ -17,17 +17,25 @@ prplInteractiveTaskFormListener.customSubmit( {
 			'#prpl-popover-rename-uncategorized-category input[name="prpl_uncategorized_category_slug"]'
 		);
 
-		fetch( progressPlanner.ajaxUrl, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/x-www-form-urlencoded',
-			},
-			body: new URLSearchParams( {
-				action: 'prpl_interactive_task_submit_rename-uncategorized-category',
-				nonce: progressPlanner.nonce,
-				uncategorized_category_name: name.value,
-				uncategorized_category_slug: slug.value,
-			} ),
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_rename-uncategorized-category',
+					nonce: progressPlanner.nonce,
+					uncategorized_category_name: name.value,
+					uncategorized_category_slug: slug.value,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
 		} );
 	},
 } );

--- a/assets/js/recommendations/update-term-description.js
+++ b/assets/js/recommendations/update-term-description.js
@@ -177,21 +177,32 @@
 				taskId: this.currentTaskElement.dataset.taskId,
 				popoverId: this.popoverId,
 				callback: () => {
-					fetch( progressPlanner.ajaxUrl, {
-						method: 'POST',
-						headers: {
-							'Content-Type': 'application/x-www-form-urlencoded',
-						},
-						body: new URLSearchParams( {
-							action: 'prpl_interactive_task_submit_update-term-description',
-							nonce: progressPlanner.nonce,
-							term_id: this.elements.termIdField.value,
-							taxonomy: this.elements.taxonomyField.value,
-							description: this.elements.descriptionField.value,
-						} ),
-					} ).then( () => {
-						this.currentTaskElement = null;
-						this.currentTermData = null;
+					return new Promise( ( resolve, reject ) => {
+						fetch( progressPlanner.ajaxUrl, {
+							method: 'POST',
+							headers: {
+								'Content-Type':
+									'application/x-www-form-urlencoded',
+							},
+							body: new URLSearchParams( {
+								action: 'prpl_interactive_task_submit_update-term-description',
+								nonce: progressPlanner.nonce,
+								term_id: this.elements.termIdField.value,
+								taxonomy: this.elements.taxonomyField.value,
+								description:
+									this.elements.descriptionField.value,
+							} ),
+						} )
+							.then( () => {
+								this.currentTaskElement = null;
+								this.currentTermData = null;
+							} )
+							.then( ( response ) => {
+								resolve( { response, success: true } );
+							} )
+							.catch( ( error ) => {
+								reject( { success: false, error } );
+							} );
 					} );
 				},
 			} );

--- a/classes/suggested-tasks/providers/class-remove-terms-without-posts.php
+++ b/classes/suggested-tasks/providers/class-remove-terms-without-posts.php
@@ -321,12 +321,22 @@ class Remove_Terms_Without_Posts extends Tasks_Interactive {
 	 * @return array
 	 */
 	public function add_task_actions( $data = [], $actions = [] ) {
-		$term = $this->get_term_from_task_id( $data['meta']['prpl_task_id'] );
+
+		if ( ! isset( $data['slug'] ) ) {
+			return $actions;
+		}
+
+		$term = $this->get_term_from_task_id( \progress_planner()->get_suggested_tasks()->get_task_id_from_slug( $data['slug'] ) );
+
+		// If the term is not found, return the actions.
+		if ( ! $term ) {
+			return $actions;
+		}
 
 		$task_data = [
-			'target_term_id'   => $term->term_id ?? '',
-			'target_taxonomy'  => $term->taxonomy ?? '',
-			'target_term_name' => $term->name ?? '',
+			'target_term_id'   => $term->term_id,
+			'target_taxonomy'  => $term->taxonomy,
+			'target_term_name' => $term->name,
 		];
 
 		$task_details = $this->get_task_details( $task_data );

--- a/classes/suggested-tasks/providers/class-update-term-description.php
+++ b/classes/suggested-tasks/providers/class-update-term-description.php
@@ -311,6 +311,8 @@ class Update_Term_Description extends Tasks_Interactive {
 		}
 
 		$term = $this->get_term_from_task_id( \progress_planner()->get_suggested_tasks()->get_task_id_from_slug( $data['slug'] ) );
+
+		// If the term is not found, return the actions.
 		if ( ! $term ) {
 			return $actions;
 		}

--- a/classes/suggested-tasks/providers/integrations/yoast/class-add-yoast-providers.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-add-yoast-providers.php
@@ -28,6 +28,8 @@ class Add_Yoast_Providers {
 			\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 
 			\add_filter( 'progress_planner_exclude_public_taxonomies', [ $this, 'exclude_not_indexable_taxonomies' ] );
+
+			\add_filter( 'progress_planner_interactive_task_allowed_options', [ $this, 'add_interactive_task_allowed_options' ] );
 		}
 	}
 
@@ -120,5 +122,16 @@ class Add_Yoast_Providers {
 		}
 
 		return $exclude_taxonomies;
+	}
+
+	/**
+	 * Add the interactive task allowed options.
+	 *
+	 * @param array $allowed_options The allowed options.
+	 * @return array
+	 */
+	public function add_interactive_task_allowed_options( $allowed_options ) {
+		$allowed_options[] = 'wpseo';
+		return $allowed_options;
 	}
 }


### PR DESCRIPTION
Interactive tasks were broken in multiple ways:

- In https://github.com/ProgressPlanner/progress-planner/pull/586 we added a way to handle failed request for interactive tasks, but in https://github.com/ProgressPlanner/progress-planner/pull/663 we converted new tasks to be interactive. The tasks which were added later needed to be adjusted.
- `wpseo` was missing from the `allowed options to update` list
- `remove terms without posts` needed to be adjusted for the new way of how we store `task_id`

I started fixing one issue, which @tacoverdo reported, but then while testing I discovered more and fixed them - but another round of interactive tasks testing would be good.