### PR TITLE
Add spinner (loader) to the interactive tasks forms

### DIFF
--- a/assets/css/page-widgets/suggested-tasks.css
+++ b/assets/css/page-widgets/suggested-tasks.css
@@ -441,9 +441,21 @@
 			padding-top: 1rem;
 			display: flex;
 			justify-content: flex-end;
+			align-items: center;
 			gap: 1rem;
 			align-self: flex-end;
 			width: 100%;
+
+			/* If there are no other elements in the form, align the button to the left. */
+			&:only-child {
+				padding-top: 0;
+				justify-content: flex-start;
+
+				/* Display the spinner after the button. */
+				.prpl-spinner {
+					order: 99;
+				}
+			}
 
 			.prpl-button {
 				cursor: pointer;
@@ -454,6 +466,11 @@
 					pointer-events: none;
 					opacity: 0.5;
 				}
+			}
+
+			/* Display the spinner before the button. */
+			.prpl-spinner {
+				order: -1;
 			}
 
 		}

--- a/assets/css/page-widgets/suggested-tasks.css
+++ b/assets/css/page-widgets/suggested-tasks.css
@@ -206,6 +206,10 @@
 			&.prpl-note-error {
 				color: var(--prpl-color-alert-error-text);
 				background-color: var(--prpl-background-alert-error);
+				margin-bottom: 0;
+
+				order: 98; /* One less than the spinner. */
+				flex-grow: 1;
 
 				.prpl-note-icon {
 					color: var(--prpl-color-alert-error);

--- a/assets/js/recommendations/interactive-task.js
+++ b/assets/js/recommendations/interactive-task.js
@@ -35,6 +35,8 @@ const prplInteractiveTaskFormListener = {
 		formElement.addEventListener( 'submit', ( event ) => {
 			event.preventDefault();
 
+			prplInteractiveTaskFormListener.showLoading( formElement );
+
 			// Get the form data.
 			const formData = new FormData( formElement );
 			const settingsToPass = {};
@@ -56,6 +58,8 @@ const prplInteractiveTaskFormListener = {
 						return response;
 					}
 
+					prplInteractiveTaskFormListener.hideLoading( formElement );
+
 					// This will trigger the celebration event (confetti) as well.
 					prplSuggestedTask.maybeComplete( postId ).then( () => {
 						// Close popover.
@@ -75,6 +79,8 @@ const prplInteractiveTaskFormListener = {
 
 		const formSubmitHandler = ( event ) => {
 			event.preventDefault();
+
+			prplInteractiveTaskFormListener.showLoading( formElement );
 
 			callback()
 				.then( ( response ) => {
@@ -110,6 +116,9 @@ const prplInteractiveTaskFormListener = {
 					);
 				} )
 				.finally( () => {
+					// Hide loading state.
+					prplInteractiveTaskFormListener.hideLoading( formElement );
+
 					// Remove the form listener once the callback is executed.
 					formElement.removeEventListener(
 						'submit',
@@ -139,6 +148,8 @@ const prplInteractiveTaskFormListener = {
 		formElement.addEventListener( 'submit', ( event ) => {
 			event.preventDefault();
 
+			prplInteractiveTaskFormListener.showLoading( formElement );
+
 			const formData = new FormData( formElement );
 			const settingsToPass = {};
 			settingsToPass[ setting ] = settingCallbackValue(
@@ -157,7 +168,6 @@ const prplInteractiveTaskFormListener = {
 				},
 			} )
 				.then( ( response ) => {
-					console.log( response );
 					if ( true !== response.success ) {
 						// Show error to the user.
 						prplInteractiveTaskFormListener.showError(
@@ -193,6 +203,10 @@ const prplInteractiveTaskFormListener = {
 						error,
 						popoverId
 					);
+				} )
+				.finally( () => {
+					// Hide loading state.
+					prplInteractiveTaskFormListener.hideLoading( formElement );
 				} );
 		} );
 	},
@@ -240,5 +254,36 @@ const prplInteractiveTaskFormListener = {
 				submitButton
 			);
 		}
+	},
+
+	/**
+	 * Show loading state.
+	 *
+	 * @param {HTMLFormElement} formElement - The form element.
+	 * @return {void}
+	 */
+	showLoading: ( formElement ) => {
+		// data-action="completeTask"
+		formElement.querySelector( 'button[type="submit"]' ).disabled = true;
+
+		// Add spinner.
+		const spinner = document.createElement( 'span' );
+		spinner.classList.add( 'prpl-spinner' );
+		spinner.innerHTML =
+			'<span class="spinner" style="visibility: visible;"></span>'; // WP spinner.
+
+		// Append spinner after submit button.
+		formElement.querySelector( 'button[type="submit"]' ).after( spinner );
+	},
+
+	/**
+	 * Hide loading state.
+	 *
+	 * @param {HTMLFormElement} formElement - The form element.
+	 * @return {void}
+	 */
+	hideLoading: ( formElement ) => {
+		formElement.querySelector( 'button[type="submit"]' ).disabled = false;
+		formElement.querySelector( 'span.prpl-spinner' )?.remove();
 	},
 };

--- a/assets/js/recommendations/interactive-task.js
+++ b/assets/js/recommendations/interactive-task.js
@@ -228,17 +228,12 @@ const prplInteractiveTaskFormListener = {
 
 		console.error( 'Error in interactive task callback:', error );
 
-		// Add error message.
-		const submitButton = formElement.querySelector(
-			'button[type="submit"]'
+		// Check if there's already an error message <p> element right after the form
+		const existingErrorElement = formElement.parentNode.querySelector(
+			'p.prpl-interactive-task-error-message'
 		);
 
-		if (
-			submitButton &&
-			! formElement.querySelector(
-				'.prpl-interactive-task-error-message'
-			)
-		) {
+		if ( ! existingErrorElement ) {
 			// Add paragraph with error message.
 			const errorParagraph = document.createElement( 'p' );
 			errorParagraph.classList.add(
@@ -248,11 +243,8 @@ const prplInteractiveTaskFormListener = {
 			);
 			errorParagraph.textContent = prplL10n( 'somethingWentWrong' );
 
-			// Append before submit button.
-			submitButton.parentNode.insertBefore(
-				errorParagraph,
-				submitButton
-			);
+			// Append after the form element.
+			formElement.insertAdjacentElement( 'afterend', errorParagraph );
 		}
 	},
 
@@ -263,8 +255,15 @@ const prplInteractiveTaskFormListener = {
 	 * @return {void}
 	 */
 	showLoading: ( formElement ) => {
-		// data-action="completeTask"
-		formElement.querySelector( 'button[type="submit"]' ).disabled = true;
+		let submitButton = formElement.querySelector( 'button[type="submit"]' );
+
+		if ( ! submitButton ) {
+			submitButton = formElement.querySelector(
+				'button[data-action="completeTask"]'
+			);
+		}
+
+		submitButton.disabled = true;
 
 		// Add spinner.
 		const spinner = document.createElement( 'span' );
@@ -273,7 +272,7 @@ const prplInteractiveTaskFormListener = {
 			'<span class="spinner" style="visibility: visible;"></span>'; // WP spinner.
 
 		// Append spinner after submit button.
-		formElement.querySelector( 'button[type="submit"]' ).after( spinner );
+		submitButton.after( spinner );
 	},
 
 	/**
@@ -283,7 +282,18 @@ const prplInteractiveTaskFormListener = {
 	 * @return {void}
 	 */
 	hideLoading: ( formElement ) => {
-		formElement.querySelector( 'button[type="submit"]' ).disabled = false;
-		formElement.querySelector( 'span.prpl-spinner' )?.remove();
+		let submitButton = formElement.querySelector( 'button[type="submit"]' );
+
+		if ( ! submitButton ) {
+			submitButton = formElement.querySelector(
+				'button[data-action="completeTask"]'
+			);
+		}
+
+		submitButton.disabled = false;
+		const spinner = formElement.querySelector( 'span.prpl-spinner' );
+		if ( spinner ) {
+			spinner.remove();
+		}
 	},
 };

--- a/classes/suggested-tasks/providers/class-blog-description.php
+++ b/classes/suggested-tasks/providers/class-blog-description.php
@@ -123,9 +123,11 @@ class Blog_Description extends Tasks_Interactive {
 				placeholder="<?php \esc_html_e( 'A catchy phrase to describe your website', 'progress-planner' ); ?>"
 			>
 		</label>
-		<button type="submit" class="prpl-button prpl-button-primary" disabled>
-			<?php \esc_html_e( 'Save', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary" disabled>
+				<?php \esc_html_e( 'Save', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/class-disable-comment-pagination.php
+++ b/classes/suggested-tasks/providers/class-disable-comment-pagination.php
@@ -121,9 +121,11 @@ class Disable_Comment_Pagination extends Tasks_Interactive {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Disable comment pagination', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Disable comment pagination', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/class-disable-comment-pagination.php
+++ b/classes/suggested-tasks/providers/class-disable-comment-pagination.php
@@ -120,13 +120,7 @@ class Disable_Comment_Pagination extends Tasks_Interactive {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Disable comment pagination', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Disable comment pagination', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-disable-comments.php
+++ b/classes/suggested-tasks/providers/class-disable-comments.php
@@ -144,9 +144,11 @@ class Disable_Comments extends Tasks_Interactive {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Disable new comments', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper" style="justify-content: flex-start;margin-bottom: 1.25rem;">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Disable new comments', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php if ( ! \is_multisite() && \current_user_can( 'install_plugins' ) ) : ?>
 			<prpl-install-plugin
 				data-plugin-name="Comment-free zone"

--- a/classes/suggested-tasks/providers/class-disable-comments.php
+++ b/classes/suggested-tasks/providers/class-disable-comments.php
@@ -145,7 +145,7 @@ class Disable_Comments extends Tasks_Interactive {
 	public function print_popover_form_contents() {
 		?>
 		<div class="prpl-steps-nav-wrapper" style="justify-content: flex-start;margin-bottom: 1.25rem;">
-			<button type="submit" class="prpl-button prpl-button-primary">
+			<button type="submit" class="prpl-button prpl-button-primary" style="order:-2;">
 				<?php \esc_html_e( 'Disable new comments', 'progress-planner' ); ?>
 			</button>
 		</div>

--- a/classes/suggested-tasks/providers/class-hello-world.php
+++ b/classes/suggested-tasks/providers/class-hello-world.php
@@ -140,9 +140,11 @@ class Hello_World extends Tasks_Interactive {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Delete the "Hello World!" post', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Delete the "Hello World!" post', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/class-hello-world.php
+++ b/classes/suggested-tasks/providers/class-hello-world.php
@@ -139,13 +139,7 @@ class Hello_World extends Tasks_Interactive {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Delete the "Hello World!" post', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Delete the "Hello World!" post', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-permalink-structure.php
+++ b/classes/suggested-tasks/providers/class-permalink-structure.php
@@ -236,13 +236,8 @@ class Permalink_Structure extends Tasks_Interactive {
 				</div>
 			</fieldset>
 		</div>
-
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Set permalink structure', 'progress-planner' ); ?>
-			</button>
-		</div>
 		<?php
+		$this->print_submit_button( \__( 'Set permalink structure', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-permalink-structure.php
+++ b/classes/suggested-tasks/providers/class-permalink-structure.php
@@ -236,9 +236,12 @@ class Permalink_Structure extends Tasks_Interactive {
 				</div>
 			</fieldset>
 		</div>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Set permalink structure', 'progress-planner' ); ?>
-		</button>
+
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Set permalink structure', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/providers/class-sample-page.php
@@ -139,9 +139,11 @@ class Sample_Page extends Tasks_Interactive {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Delete the "Sample Page" page', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Delete the "Sample Page" page', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/providers/class-sample-page.php
@@ -138,13 +138,7 @@ class Sample_Page extends Tasks_Interactive {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Delete the "Sample Page" page', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Delete the "Sample Page" page', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/providers/class-search-engine-visibility.php
@@ -113,9 +113,11 @@ class Search_Engine_Visibility extends Tasks_Interactive {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Allow search engines to index your site', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Allow search engines to index your site', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/class-search-engine-visibility.php
+++ b/classes/suggested-tasks/providers/class-search-engine-visibility.php
@@ -112,13 +112,7 @@ class Search_Engine_Visibility extends Tasks_Interactive {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Allow search engines to index your site', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Allow search engines to index your site', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-select-locale.php
+++ b/classes/suggested-tasks/providers/class-select-locale.php
@@ -225,13 +225,8 @@ class Select_Locale extends Tasks_Interactive {
 				'show_available_translations' => \current_user_can( 'install_languages' ) && \wp_can_install_language_pack(),
 			]
 		);
-		?>
-		<div class="prpl-steps-nav-wrapper">
-		<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Select locale', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+
+		$this->print_submit_button( \__( 'Select locale', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-select-locale.php
+++ b/classes/suggested-tasks/providers/class-select-locale.php
@@ -226,9 +226,11 @@ class Select_Locale extends Tasks_Interactive {
 			]
 		);
 		?>
+		<div class="prpl-steps-nav-wrapper">
 		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Select locale', 'progress-planner' ); ?>
-		</button>
+				<?php \esc_html_e( 'Select locale', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/class-select-timezone.php
+++ b/classes/suggested-tasks/providers/class-select-timezone.php
@@ -143,12 +143,8 @@ class Select_Timezone extends Tasks_Interactive {
 				<?php echo \wp_timezone_choice( $tzstring, \get_user_locale() ); ?>
 			</select>
 		</label>
-		<div class="prpl-steps-nav-wrapper">
-		<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Set site timezone', 'progress-planner' ); ?>
-			</button>
-		</div>
 		<?php
+		$this->print_submit_button( \__( 'Set site timezone', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-select-timezone.php
+++ b/classes/suggested-tasks/providers/class-select-timezone.php
@@ -143,9 +143,11 @@ class Select_Timezone extends Tasks_Interactive {
 				<?php echo \wp_timezone_choice( $tzstring, \get_user_locale() ); ?>
 			</select>
 		</label>
+		<div class="prpl-steps-nav-wrapper">
 		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Set site timezone', 'progress-planner' ); ?>
-		</button>
+				<?php \esc_html_e( 'Set site timezone', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/class-set-date-format.php
+++ b/classes/suggested-tasks/providers/class-set-date-format.php
@@ -242,9 +242,11 @@ class Set_Date_Format extends Tasks_Interactive {
 				</p>
 			</fieldset>
 		</div>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Set date format', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Set date format', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/class-set-date-format.php
+++ b/classes/suggested-tasks/providers/class-set-date-format.php
@@ -242,12 +242,8 @@ class Set_Date_Format extends Tasks_Interactive {
 				</p>
 			</fieldset>
 		</div>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Set date format', 'progress-planner' ); ?>
-			</button>
-		</div>
 		<?php
+		$this->print_submit_button( \__( 'Set date format', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-site-icon.php
+++ b/classes/suggested-tasks/providers/class-site-icon.php
@@ -120,9 +120,11 @@ class Site_Icon extends Tasks_Interactive {
 			<?php \esc_html_e( 'Choose or Upload Image', 'progress-planner' ); ?>
 		</button>
 		<input type="hidden" name="site_icon" id="prpl-site-icon-id" value="<?php echo \esc_attr( $site_icon_id ); ?>">
-		<button type="submit" class="prpl-button prpl-button-primary" id="prpl-set-site-icon-button" <?php echo $site_icon_id ? '' : 'disabled'; ?>>
-			<?php \esc_html_e( 'Set site icon', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary" id="prpl-set-site-icon-button" <?php echo $site_icon_id ? '' : 'disabled'; ?>>
+				<?php \esc_html_e( 'Set site icon', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/class-tasks-interactive.php
+++ b/classes/suggested-tasks/providers/class-tasks-interactive.php
@@ -207,6 +207,27 @@ abstract class Tasks_Interactive extends Tasks {
 	}
 
 	/**
+	 * Print the submit button.
+	 *
+	 * @param string $button_text The text for the button.
+	 *                           If empty, the default text "Submit" will be used.
+	 *
+	 * @return void
+	 */
+	protected function print_submit_button( $button_text = '' ) {
+		if ( empty( $button_text ) ) {
+			$button_text = \__( 'Submit', 'progress-planner' );
+		}
+		?>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php echo \esc_html( $button_text ); ?>
+			</button>
+		</div>
+		<?php
+	}
+
+	/**
 	 * Print the popover form contents.
 	 *
 	 * @return void

--- a/classes/suggested-tasks/providers/class-update-term-description.php
+++ b/classes/suggested-tasks/providers/class-update-term-description.php
@@ -389,9 +389,11 @@ class Update_Term_Description extends Tasks_Interactive {
 		></textarea>
 		<input type="hidden" name="term_id" id="prpl-update-term-id" value="">
 		<input type="hidden" name="taxonomy" id="prpl-update-taxonomy" value="">
-		<button type="submit" class="prpl-button prpl-button-primary" id="prpl-update-term-description-button">
-			<?php \esc_html_e( 'Save description', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary" id="prpl-update-term-description-button">
+				<?php \esc_html_e( 'Save description', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-archive-author.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-archive-author.php
@@ -136,9 +136,11 @@ class Archive_Author extends AIOSEO_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Noindex the author archive', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Noindex the author archive', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-archive-author.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-archive-author.php
@@ -135,13 +135,7 @@ class Archive_Author extends AIOSEO_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Noindex the author archive', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Noindex the author archive', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-archive-date.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-archive-date.php
@@ -122,9 +122,11 @@ class Archive_Date extends AIOSEO_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
+		<div class="prpl-steps-nav-wrapper">
 		<button type="submit" class="prpl-button prpl-button-primary">
 			<?php \esc_html_e( 'Noindex the date archive', 'progress-planner' ); ?>
 		</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-archive-date.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-archive-date.php
@@ -121,13 +121,7 @@ class Archive_Date extends AIOSEO_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Noindex the date archive', 'progress-planner' ); ?>
-		</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Noindex the date archive', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-authors.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-authors.php
@@ -132,13 +132,7 @@ class Crawl_Settings_Feed_Authors extends AIOSEO_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Disable author RSS feeds', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Disable author RSS feeds', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-authors.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-authors.php
@@ -133,9 +133,11 @@ class Crawl_Settings_Feed_Authors extends AIOSEO_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Disable author RSS feeds', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Disable author RSS feeds', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-comments.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-comments.php
@@ -100,13 +100,7 @@ class Crawl_Settings_Feed_Comments extends AIOSEO_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Disable comment RSS feeds', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Disable comment RSS feeds', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-comments.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-comments.php
@@ -101,9 +101,11 @@ class Crawl_Settings_Feed_Comments extends AIOSEO_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Disable comment RSS feeds', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Disable comment RSS feeds', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-add-yoast-providers.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-add-yoast-providers.php
@@ -132,6 +132,7 @@ class Add_Yoast_Providers {
 	 */
 	public function add_interactive_task_allowed_options( $allowed_options ) {
 		$allowed_options[] = 'wpseo';
+		$allowed_options[] = 'wpseo_titles';
 		return $allowed_options;
 	}
 }

--- a/classes/suggested-tasks/providers/integrations/yoast/class-archive-author.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-archive-author.php
@@ -126,9 +126,11 @@ class Archive_Author extends Yoast_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-archive-author.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-archive-author.php
@@ -125,13 +125,7 @@ class Archive_Author extends Yoast_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Disable', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/yoast/class-archive-date.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-archive-date.php
@@ -112,13 +112,7 @@ class Archive_Date extends Yoast_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Disable', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/yoast/class-archive-date.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-archive-date.php
@@ -113,9 +113,11 @@ class Archive_Date extends Yoast_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-archive-format.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-archive-format.php
@@ -126,9 +126,11 @@ class Archive_Format extends Yoast_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
+		<div class="prpl-steps-nav-wrapper">
 		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
-		</button>
+				<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-archive-format.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-archive-format.php
@@ -125,13 +125,7 @@ class Archive_Format extends Yoast_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-		<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Disable', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-emoji-scripts.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-emoji-scripts.php
@@ -104,13 +104,7 @@ class Crawl_Settings_Emoji_Scripts extends Yoast_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Remove', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Remove', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-emoji-scripts.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-emoji-scripts.php
@@ -105,9 +105,11 @@ class Crawl_Settings_Emoji_Scripts extends Yoast_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Remove', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Remove', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
@@ -137,9 +137,11 @@ class Crawl_Settings_Feed_Authors extends Yoast_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Remove', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Remove', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-authors.php
@@ -136,13 +136,7 @@ class Crawl_Settings_Feed_Authors extends Yoast_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Remove', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Remove', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-global-comments.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-global-comments.php
@@ -104,13 +104,7 @@ class Crawl_Settings_Feed_Global_Comments extends Yoast_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-		<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Remove', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Remove', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-global-comments.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-crawl-settings-feed-global-comments.php
@@ -105,9 +105,11 @@ class Crawl_Settings_Feed_Global_Comments extends Yoast_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
+		<div class="prpl-steps-nav-wrapper">
 		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Remove', 'progress-planner' ); ?>
-		</button>
+				<?php \esc_html_e( 'Remove', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-media-pages.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-media-pages.php
@@ -98,13 +98,7 @@ class Media_Pages extends Yoast_Interactive_Provider {
 	 * @return void
 	 */
 	public function print_popover_form_contents() {
-		?>
-		<div class="prpl-steps-nav-wrapper">
-			<button type="submit" class="prpl-button prpl-button-primary">
-				<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
-			</button>
-		</div>
-		<?php
+		$this->print_submit_button( \__( 'Disable', 'progress-planner' ) );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/yoast/class-media-pages.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-media-pages.php
@@ -99,9 +99,11 @@ class Media_Pages extends Yoast_Interactive_Provider {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<button type="submit" class="prpl-button prpl-button-primary">
-			<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary">
+				<?php \esc_html_e( 'Disable', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 

--- a/classes/suggested-tasks/providers/integrations/yoast/class-organization-logo.php
+++ b/classes/suggested-tasks/providers/integrations/yoast/class-organization-logo.php
@@ -191,9 +191,11 @@ class Organization_Logo extends Yoast_Interactive_Provider {
 			<?php \esc_html_e( 'Choose or Upload Image', 'progress-planner' ); ?>
 		</button>
 		<input type="hidden" name="prpl_yoast_organization_logo_id" id="prpl-yoast-organization-logo-id" value="<?php echo \esc_attr( $organization_logo_id ); ?>">
-		<button type="submit" class="prpl-button prpl-button-primary" id="prpl-set-organization-logo-button" <?php echo $organization_logo_id ? '' : 'disabled'; ?>>
-			<?php \esc_html_e( 'Set logo', 'progress-planner' ); ?>
-		</button>
+		<div class="prpl-steps-nav-wrapper">
+			<button type="submit" class="prpl-button prpl-button-primary" id="prpl-set-organization-logo-button" <?php echo $organization_logo_id ? '' : 'disabled'; ?>>
+				<?php \esc_html_e( 'Set logo', 'progress-planner' ); ?>
+			</button>
+		</div>
 		<?php
 	}
 


### PR DESCRIPTION
Inspired by [this comment](https://github.com/ProgressPlanner/progress-planner/pull/628#issuecomment-3442109498)

Interactive tasks look similar, almost the same, but their HTML structure and the way they are submitted is different.
One example of different HTML structure is how submit button is positioned, for tasks which have multiple steps it is in the bottom right corner. But tasks which only have that button (like "Disable comments") will have it in the top left.

Spinner needs to be added to the side of the button which has available space (so the button is not moved when spinner is visible) and I have tried not to change how buttons were positioned before, but because there are many different variations another round of testing would be good.