### PR TITLE
Add spinner to onboarding form and remove success message

### DIFF
--- a/assets/css/onboard.css
+++ b/assets/css/onboard.css
@@ -16,3 +16,8 @@
 		display: block !important;
 	}
 }
+
+#prpl-onboarding-submit-wrapper {
+	display: flex;
+	align-items: center;
+}

--- a/assets/js/onboard.js
+++ b/assets/js/onboard.js
@@ -35,17 +35,6 @@ const progressPlannerAjaxAPIRequest = ( data ) => {
 		data,
 	} )
 		.then( ( response ) => {
-			// Show success message.
-			document.getElementById(
-				'no-license' === response.license_key
-					? 'prpl-account-not-created-message'
-					: 'prpl-account-created-message'
-			).style.display = 'block';
-
-			// Hide the form.
-			document.getElementById( 'prpl-onboarding-form' ).style.display =
-				'none';
-
 			// Make a local request to save the response data.
 			progressPlannerSaveLicenseKey( response.license_key ).then( () => {
 				// Refresh the page.
@@ -144,9 +133,26 @@ if ( document.getElementById( 'prpl-onboarding-form' ) ) {
 				return;
 			}
 
-			document.querySelector(
-				'#prpl-onboarding-form input[type="submit"]'
-			).disabled = true;
+			// Disable all (both buttons) submit buttons.
+			document
+				.querySelectorAll(
+					'#prpl-onboarding-form input[type="submit"]'
+				)
+				.forEach( ( input ) => {
+					input.disabled = true;
+				} );
+
+			// Show the spinner.
+			const spinner = document.createElement( 'span' );
+			spinner.classList.add( 'prpl-spinner' );
+			spinner.innerHTML =
+				'<span class="spinner" style="visibility: visible;"></span>'; // WP spinner.
+
+			// Append spinner after submit button.
+
+			document
+				.getElementById( 'prpl-onboarding-submit-wrapper' )
+				.appendChild( spinner );
 
 			// Get all form data.
 			const data = Object.fromEntries( new FormData( event.target ) );

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -145,21 +145,6 @@ if ( false !== \get_option( 'progress_planner_license_key', false ) ) {
 					>
 				</div>
 			</form>
-
-			<div>
-				<p id="prpl-account-created-message" style="display:none;">
-					<?php
-					\printf(
-						/* translators: %s: progressplanner.com link */
-						\esc_html__( 'Success! We saved your data on %s so we can email you every week.', 'progress-planner' ),
-						'<a href="' . \esc_url( \progress_planner()->get_ui__branding()->get_url( 'https://prpl.fyi/home' ) ) . '">ProgressPlanner.com</a>'
-					);
-					?>
-				</p>
-				<p id="prpl-account-not-created-message" style="display:none;">
-					<?php \esc_html_e( 'Success! Enjoy using the Progress Planner plugin!', 'progress-planner' ); ?>
-				</p>
-			</div>
 		</div>
 		<div class="right">
 			<img


### PR DESCRIPTION
This PR removes the success message from the onboarding form. In the past there, in the background, site content was scanned but it doesnt serve much purpose since that was removed.

Besides that spinner is added to the onboard form once it is submitted, also adding the disabled attribute is corrected (so now it is added to both submit buttons) so user knows something is happening.