### PR TITLE
Fix "check irrelevant tasks" for "Delete term without posts" and "Update term description" tasks

### DIFF
--- a/classes/suggested-tasks/providers/class-remove-terms-without-posts.php
+++ b/classes/suggested-tasks/providers/class-remove-terms-without-posts.php
@@ -115,6 +115,14 @@ class Remove_Terms_Without_Posts extends Tasks_Interactive {
 	 * @return void
 	 */
 	public function maybe_remove_irrelevant_tasks( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
+
+		$taxonomy_object = \get_taxonomy( $taxonomy );
+
+		// Check if the taxonomy is public, we are not interested in non-public taxonomies (also our data collector doesn't track non-public taxonomies).
+		if ( ! $taxonomy_object || ! $taxonomy_object->public ) {
+			return;
+		}
+
 		foreach ( \progress_planner()->get_suggested_tasks_db()->get_tasks_by( [ 'provider_id' => $this->get_provider_id() ] ) as $task ) {
 			/**
 			 * The task post object.

--- a/classes/suggested-tasks/providers/class-update-term-description.php
+++ b/classes/suggested-tasks/providers/class-update-term-description.php
@@ -107,6 +107,14 @@ class Update_Term_Description extends Tasks_Interactive {
 	 * @return void
 	 */
 	public function maybe_remove_irrelevant_tasks( $term, $tt_id, $taxonomy, $deleted_term, $object_ids ) {
+
+		$taxonomy_object = \get_taxonomy( $taxonomy );
+
+		// Check if the taxonomy is public, we are not interested in non-public taxonomies (also our data collector doesn't track non-public taxonomies).
+		if ( ! $taxonomy_object || ! $taxonomy_object->public ) {
+			return;
+		}
+
 		$pending_tasks = \progress_planner()->get_suggested_tasks_db()->get_tasks_by( [ 'provider_id' => $this->get_provider_id() ] );
 
 		if ( ! $pending_tasks ) {


### PR DESCRIPTION
While testing for v1.9 this morning @tacoverdo and I noticed that a task for "Delete term without" posts, which was created properly, gets marked as completed without term actually being deleted.

After some debugging I found that it actually happens because `maybe_remove_irrelevant_tasks` methods were called for all PP specific (not public taxonomy).

Besides that not being needed, since we're interested only in the public taxonomies, it also created a bug because the taxonomies are assigned before the post meta - and we need post meta in order for `$term` to be fetched [here](https://github.com/Emilia-Capital/progress-planner/blob/959b6e0053f7da65ced37e53cde3a2db4b2eed40/classes/suggested-tasks/providers/class-update-term-description.php#L186).

Since post meta was missing, `$term` had a value of `NULL` and the recommendation was marked as completed.

This PR fixes that issue.