### PR TITLE
Fix missing JS global variable on WP Dashboard page (again)

### DIFF
--- a/assets/js/web-components/prpl-install-plugin.js
+++ b/assets/js/web-components/prpl-install-plugin.js
@@ -1,4 +1,4 @@
-/* global customElements, HTMLElement, prplL10n, progressPlannerAjaxRequest, prplSuggestedTask */
+/* global customElements, HTMLElement, prplL10n, progressPlanner, progressPlannerAjaxRequest, prplSuggestedTask */
 /*
  * Install Plugin
  *
@@ -19,7 +19,7 @@ customElements.define(
 			action,
 			providerId,
 			className = 'prpl-button-link',
-			completeTask = 'true' // String on purpose, since element attributes are always strings.
+			completeTaskAttr = 'true' // String on purpose, since element attributes are always strings.
 		) {
 			// Get parent class properties
 			super();
@@ -30,8 +30,8 @@ customElements.define(
 				pluginName ?? this.getAttribute( 'data-plugin-name' );
 			this.pluginName = this.pluginName ?? this.pluginSlug;
 			this.action = action ?? this.getAttribute( 'data-action' );
-			this.completeTask =
-				completeTask ?? this.getAttribute( 'data-complete-task' );
+			this.completeTaskAttr =
+				completeTaskAttr ?? this.getAttribute( 'data-complete-task' );
 			this.providerId =
 				providerId ?? this.getAttribute( 'data-provider-id' );
 			this.className = className ?? this.getAttribute( 'class' );
@@ -41,7 +41,7 @@ customElements.define(
 			}
 
 			// Convert the string to a boolean.
-			this.completeTask = 'true' === this.completeTask;
+			this.completeTaskAttr = 'true' === this.completeTaskAttr;
 
 			// Set the inner HTML.
 			this.innerHTML = `
@@ -87,12 +87,12 @@ customElements.define(
 			`;
 
 			progressPlannerAjaxRequest( {
-				url: this.getAjaxUrl(),
+				url: progressPlanner.ajaxUrl,
 				data: {
 					action: 'progress_planner_install_plugin',
 					plugin_slug: this.pluginSlug,
 					plugin_name: this.pluginName,
-					nonce: this.getNonce(),
+					nonce: progressPlanner.nonce,
 				},
 			} )
 				.then( () => thisObj.activatePlugin() )
@@ -108,19 +108,19 @@ customElements.define(
 			`;
 
 			progressPlannerAjaxRequest( {
-				url: this.getAjaxUrl(),
+				url: progressPlanner.ajaxUrl,
 				data: {
 					action: 'progress_planner_activate_plugin',
 					plugin_slug: thisObj.pluginSlug,
 					plugin_name: thisObj.pluginName,
-					nonce: this.getNonce(),
+					nonce: progressPlanner.nonce,
 				},
 			} )
 				.then( () => {
 					button.innerHTML = prplL10n( 'activated' );
 
 					// Complete the task if the completeTask attribute is set to true.
-					if ( true === thisObj.completeTask ) {
+					if ( true === thisObj.completeTaskAttr ) {
 						thisObj.completeTask();
 					}
 				} )
@@ -150,26 +150,6 @@ customElements.define(
 					}
 				}
 			} );
-		}
-
-		/**
-		 * Get the AJAX URL.
-		 *
-		 * @return {string} The AJAX URL.
-		 */
-		getAjaxUrl() {
-			return window.progressPlanner?.ajaxUrl ?? window.ajaxurl;
-		}
-
-		/**
-		 * Get the nonce.
-		 *
-		 * @return {string} The nonce.
-		 */
-		getNonce() {
-			return (
-				window.progressPlanner?.nonce ?? window.prplSuggestedTask?.nonce
-			);
 		}
 	}
 );

--- a/classes/admin/class-dashboard-widget-score.php
+++ b/classes/admin/class-dashboard-widget-score.php
@@ -50,6 +50,18 @@ class Dashboard_Widget_Score extends Dashboard_Widget {
 
 		\progress_planner()->get_admin__enqueue()->enqueue_script( 'external-link-accessibility-helper' );
 
+		// Majoriry of the tasks are now interactive, we need a global object to handle the AJAX requests.
+		\progress_planner()->get_admin__enqueue()->enqueue_script(
+			'recommendations/interactive-task',
+			[
+				'name' => 'progressPlanner',
+				'data' => [
+					'ajaxUrl' => \admin_url( 'admin-ajax.php' ),
+					'nonce'   => \wp_create_nonce( 'progress_planner' ),
+				],
+			]
+		);
+
 		\progress_planner()->the_view( "dashboard-widgets/{$this->id}.php" );
 	}
 


### PR DESCRIPTION
This PR fixes the same issue as in https://github.com/ProgressPlanner/progress-planner/pull/675, but since we converted more tasks to be interactive in https://github.com/ProgressPlanner/progress-planner/pull/663 it occured for them too.

So I reverted the original fix and applied new one which defines `global progressPlanner` JS variable, to fix it for all occurrences.  I found this to be least invasive fix, as I didn't want to add onboarding URL and nonce (which we use with the variable of the same name on the PP Dashboard page).

Also this PR fixes the mistake where completeTask property overrode the function with the same name in the `prpl-install-plugin.js`. Now property has new (unique) name and function can be called without issues.