### PR TITLE
Dont celebrate all user tasks

### DIFF
--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -528,6 +528,11 @@ class Suggested_Tasks {
 				$response->data['prpl_points'] = 0;
 			}
 
+			// Assign point only to golden user task.
+			if ( 'user' === $provider->get_provider_id() ) {
+				$response->data['prpl_points'] = ( ! empty( $post->post_excerpt ) && \str_contains( $post->post_excerpt, 'GOLDEN' ) ) ? 1 : 0;
+			}
+
 			// This has to be the last item to be added because actions use data from previous items.
 			$response->data['prpl_task_actions'] = $provider->get_task_actions( $response->data );
 		}


### PR DESCRIPTION
All user tasks were triggering celebration, the data attribute on the user task DOM node had the correct value (1 for golden task, 0 for other) but the REST API response was returning 1 for all.

The response data is what determines if point is awarded and is celebration triggered, so the same check as [here](https://github.com/Emilia-Capital/progress-planner/blob/fac7ef125e34fcd4a8dee7ac09de1b66ac947614/classes/suggested-tasks/providers/class-user.php#L125) had to be applied to the REST API response filter.

This most likely worked when https://github.com/ProgressPlanner/progress-planner/pull/605 was implemented, but then later was broken in merges that followed.