### PR TITLE
Better align the submit button for interactive task forms

### DIFF
--- a/assets/css/page-widgets/suggested-tasks.css
+++ b/assets/css/page-widgets/suggested-tasks.css
@@ -453,6 +453,10 @@
 			/* If there are no other elements in the form, align the button to the left. */
 			&:only-child {
 				padding-top: 0;
+			}
+
+			&:only-child,
+			&.prpl-steps-nav-wrapper-align-left {
 				justify-content: flex-start;
 
 				/* Display the spinner after the button. */

--- a/classes/suggested-tasks/providers/class-disable-comments.php
+++ b/classes/suggested-tasks/providers/class-disable-comments.php
@@ -144,8 +144,8 @@ class Disable_Comments extends Tasks_Interactive {
 	 */
 	public function print_popover_form_contents() {
 		?>
-		<div class="prpl-steps-nav-wrapper" style="justify-content: flex-start;margin-bottom: 1.25rem;">
-			<button type="submit" class="prpl-button prpl-button-primary" style="order:-2;">
+		<div class="prpl-steps-nav-wrapper prpl-steps-nav-wrapper-align-left" style="justify-content: flex-start;margin-bottom: 1.25rem;">
+			<button type="submit" class="prpl-button prpl-button-primary">
 				<?php \esc_html_e( 'Disable new comments', 'progress-planner' ); ?>
 			</button>
 		</div>

--- a/classes/suggested-tasks/providers/class-select-locale.php
+++ b/classes/suggested-tasks/providers/class-select-locale.php
@@ -226,7 +226,7 @@ class Select_Locale extends Tasks_Interactive {
 			]
 		);
 
-		$this->print_submit_button( \__( 'Select locale', 'progress-planner' ) );
+		$this->print_submit_button( \__( 'Select locale', 'progress-planner' ), 'prpl-steps-nav-wrapper-align-left' );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-select-timezone.php
+++ b/classes/suggested-tasks/providers/class-select-timezone.php
@@ -144,7 +144,7 @@ class Select_Timezone extends Tasks_Interactive {
 			</select>
 		</label>
 		<?php
-		$this->print_submit_button( \__( 'Set site timezone', 'progress-planner' ) );
+		$this->print_submit_button( \__( 'Set site timezone', 'progress-planner' ), 'prpl-steps-nav-wrapper-align-left' );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-set-date-format.php
+++ b/classes/suggested-tasks/providers/class-set-date-format.php
@@ -243,7 +243,7 @@ class Set_Date_Format extends Tasks_Interactive {
 			</fieldset>
 		</div>
 		<?php
-		$this->print_submit_button( \__( 'Set date format', 'progress-planner' ) );
+		$this->print_submit_button( \__( 'Set date format', 'progress-planner' ), 'prpl-steps-nav-wrapper-align-left' );
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/class-site-icon.php
+++ b/classes/suggested-tasks/providers/class-site-icon.php
@@ -120,7 +120,7 @@ class Site_Icon extends Tasks_Interactive {
 			<?php \esc_html_e( 'Choose or Upload Image', 'progress-planner' ); ?>
 		</button>
 		<input type="hidden" name="site_icon" id="prpl-site-icon-id" value="<?php echo \esc_attr( $site_icon_id ); ?>">
-		<div class="prpl-steps-nav-wrapper">
+		<div class="prpl-steps-nav-wrapper prpl-steps-nav-wrapper-align-left">
 			<button type="submit" class="prpl-button prpl-button-primary" id="prpl-set-site-icon-button" <?php echo $site_icon_id ? '' : 'disabled'; ?>>
 				<?php \esc_html_e( 'Set site icon', 'progress-planner' ); ?>
 			</button>

--- a/classes/suggested-tasks/providers/class-tasks-interactive.php
+++ b/classes/suggested-tasks/providers/class-tasks-interactive.php
@@ -211,15 +211,18 @@ abstract class Tasks_Interactive extends Tasks {
 	 *
 	 * @param string $button_text The text for the button.
 	 *                           If empty, the default text "Submit" will be used.
+	 * @param string $css_class The CSS class for the wrapper.
 	 *
 	 * @return void
 	 */
-	protected function print_submit_button( $button_text = '' ) {
+	protected function print_submit_button( $button_text = '', $css_class = '' ) {
 		if ( empty( $button_text ) ) {
 			$button_text = \__( 'Submit', 'progress-planner' );
 		}
+
+		$css_class = empty( $css_class ) ? 'prpl-steps-nav-wrapper' : 'prpl-steps-nav-wrapper ' . $css_class;
 		?>
-		<div class="prpl-steps-nav-wrapper">
+		<div class="<?php echo \esc_attr( $css_class ); ?>">
 			<button type="submit" class="prpl-button prpl-button-primary">
 				<?php echo \esc_html( $button_text ); ?>
 			</button>


### PR DESCRIPTION
This PR is fine tune for the "submit" button alignment which was done in https://github.com/ProgressPlanner/progress-planner/pull/685 after the spinner was added.

If the form only has the button, and no other elements, the alignment was fine but there are other cases when that wasn't good enough - for example a select box (which is not 100% wide and a button below it, ie "set locale" or "set timezone").

This PR adds a CSS class which can be used to align button to the left if needed. 