### PR TITLE
Put back "Show all tasks" button to Debug Tool

### DIFF
--- a/classes/utils/class-debug-tools.php
+++ b/classes/utils/class-debug-tools.php
@@ -77,6 +77,16 @@ class Debug_Tools {
 			]
 		);
 
+		// Show all suggested tasks.
+		$admin_bar->add_node(
+			[
+				'id'     => 'prpl-show-all-suggested-tasks',
+				'parent' => 'prpl-debug',
+				'title'  => 'Show All Suggested Tasks',
+				'href'   => \add_query_arg( 'prpl_show_all_recommendations', $this->current_url ),
+			]
+		);
+
 		$this->add_delete_submenu_item( $admin_bar );
 
 		$this->add_upgrading_tasks_submenu_item( $admin_bar );


### PR DESCRIPTION
We had it before, but it was removed in https://github.com/ProgressPlanner/progress-planner/pull/667 since that PR added different way to show more / less recommendations on PP Dashboard page.

This PR puts the button back, but in the way which is compatible with how "show more" tasks works now and the reason is that it makes testing widgets on the WP Dashboard screen much easier.