### PR TITLE
Fix past badge points calculations

### DIFF
--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -292,9 +292,11 @@ final class Monthly extends Badge {
 	 * @return int
 	 */
 	public function get_next_badges_excess_points() {
-		$excess_points       = 0;
-		$next_1_badge_points = 0;
-		$next_2_badge_points = 0;
+		$next_1_badge_points   = 0;
+		$next_2_badge_points   = 0;
+		$badge_1_excess_points = 0;
+		$badge_2_excess_points = 0;
+
 		// Get the next badge object.
 		$next_1_badge = self::get_instance_from_id( $this->get_next_badge_id() );
 		if ( $next_1_badge ) {
@@ -306,9 +308,21 @@ final class Monthly extends Badge {
 			}
 		}
 
-		$excess_points  = \max( 0, $next_1_badge_points - self::TARGET_POINTS );
-		$excess_points += \max( 0, $next_2_badge_points - 2 * self::TARGET_POINTS );
+		// If the $next_1_badge has more than 10 points, calculate the excess points.
+		if ( $next_1_badge_points > self::TARGET_POINTS ) {
+			$badge_1_excess_points = \max( 0, $next_1_badge_points - self::TARGET_POINTS );
+		}
 
-		return (int) $excess_points;
+		// If the $next_2_badge has more than 10 points, calculate the excess points.
+		if ( $next_2_badge_points > self::TARGET_POINTS ) {
+			$badge_2_excess_points = \max( 0, $next_2_badge_points - self::TARGET_POINTS );
+
+			// Does the $next_1_badge need more points to reach 10?
+			if ( $next_1_badge_points < self::TARGET_POINTS ) {
+				$badge_2_excess_points = \max( 0, ( $next_1_badge_points + $badge_2_excess_points ) - self::TARGET_POINTS );
+			}
+		}
+
+		return (int) $badge_1_excess_points + (int) $badge_2_excess_points;
 	}
 }


### PR DESCRIPTION
The issue was reported by @tacoverdo on 2 sites, both had the same problem:

Badges for the current and previous months (October and September) were completed and August badge wasn't. When task was completed the August badge progress bar "moved" and point was increased, but when page was reloaded the the added points were missing.

The badge points which we had on the one site in question were:
- October 17
- September 16
- August 0

And the end result was that August badge had 6 points and in the progress bar.

I believe the calcs were wrong, specifically this part `$excess_points += \max( 0, $next_2_badge_points - 2 * self::TARGET_POINTS );`, since it basically nullified the extra points in the current month until 20 points are reached. I think that was not needed as the previous month (September) was already completed so the extra points should've been awarded to the August.

This PR fixes that and it checks how much points, if any, should be awarded to the previous month before awarding them to the month before it.
 