### PR TITLE
Dont enqueue assets or add popover if interactive task is not published

### DIFF
--- a/classes/suggested-tasks/providers/class-set-date-format.php
+++ b/classes/suggested-tasks/providers/class-set-date-format.php
@@ -120,6 +120,11 @@ class Set_Date_Format extends Tasks_Interactive {
 	public function print_popover_instructions() {
 		$detected_date_format = $this->get_date_format_type();
 
+		if ( ! \function_exists( 'wp_get_available_translations' ) ) {
+			// @phpstan-ignore-next-line requireOnce.fileNotFound
+			require_once ABSPATH . 'wp-admin/includes/translation-install.php';
+		}
+
 		// Get the site default language name.
 		$available_languages = \wp_get_available_translations();
 		$site_locale         = \get_locale();

--- a/classes/suggested-tasks/providers/class-tasks-interactive.php
+++ b/classes/suggested-tasks/providers/class-tasks-interactive.php
@@ -164,6 +164,11 @@ abstract class Tasks_Interactive extends Tasks {
 	 * @return void
 	 */
 	public function add_popover() {
+
+		// Don't add the popover if the task is not published.
+		if ( ! $this->is_task_published() ) {
+			return;
+		}
 		?>
 		<div id="prpl-popover-<?php echo \esc_attr( static::POPOVER_ID ); ?>" class="prpl-popover prpl-popover-interactive" popover>
 			<?php $this->the_popover_content(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
@@ -256,6 +261,11 @@ abstract class Tasks_Interactive extends Tasks {
 			return;
 		}
 
+		// Don't enqueue the script if the task is not published.
+		if ( ! $this->is_task_published() ) {
+			return;
+		}
+
 		// Enqueue the web component.
 		\progress_planner()->get_admin__enqueue()->enqueue_script(
 			'progress-planner/recommendations/' . $this->get_provider_id(),
@@ -270,5 +280,20 @@ abstract class Tasks_Interactive extends Tasks {
 	 */
 	protected function get_enqueue_data() {
 		return [];
+	}
+
+	/**
+	 * Check if the task is published.
+	 *
+	 * @return bool
+	 */
+	public function is_task_published() {
+		$tasks = \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'provider'    => $this->get_provider_id(),
+				'post_status' => 'publish',
+			]
+		);
+		return ! empty( $tasks );
 	}
 }


### PR DESCRIPTION
This is something which is bugging me for some time now - interactive tasks add popover markup and enqueue (at least one) JavaScript file. But the issue is that they do it always when the class instance is created - it doesnt matter if the task is published or not (could be that it was completed long time ago).

Currently popovers add over 2000 lines of markup, `<select>` for set locale and timezone add most of it, which is often more than the rest of the page.

This PR adds a fix for it, by checking if a published task for specific task provider exists before adding popover and enqueueing JS file.

@aristath , if you have better name for newly added `is_task_published` method please rename it.