### PR TITLE
Fix risky tests

### DIFF
--- a/tests/phpunit/traits/test-class-ajax-security-aioseo.php
+++ b/tests/phpunit/traits/test-class-ajax-security-aioseo.php
@@ -72,7 +72,7 @@ class Ajax_Security_AIOSEO_Test extends \WP_Ajax_UnitTestCase {
 		// WordPress Core's _handleAjax() starts output buffering before calling AJAX actions.
 		// We need to do the same since we're calling methods directly.
 		// WordPress Core's dieHandler() will call ob_get_clean() to clean this buffer.
-		\ini_set( 'implicit_flush', false );
+		\ini_set( 'implicit_flush', false ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		\ob_start();
 
 		// WP_Ajax_UnitTestCase allows us to test AJAX methods that call wp_send_json_error().

--- a/tests/phpunit/traits/test-class-ajax-security-aioseo.php
+++ b/tests/phpunit/traits/test-class-ajax-security-aioseo.php
@@ -69,11 +69,18 @@ class Ajax_Security_AIOSEO_Test extends \WP_Ajax_UnitTestCase {
 		// Verify aioseo function doesn't exist.
 		$this->assertFalse( \function_exists( 'aioseo' ) );
 
+		// WordPress Core's _handleAjax() starts output buffering before calling AJAX actions.
+		// We need to do the same since we're calling methods directly.
+		// WordPress Core's dieHandler() will call ob_get_clean() to clean this buffer.
+		\ini_set( 'implicit_flush', false );
+		\ob_start();
+
 		// WP_Ajax_UnitTestCase allows us to test AJAX methods that call wp_send_json_error().
 		try {
 			$this->mock_class->public_verify_aioseo_active_or_fail();
 			$this->fail( 'Expected WPAjaxDieContinueException was not thrown' );
 		} catch ( \WPAjaxDieContinueException $e ) {
+			// WordPress Core's dieHandler() calls ob_get_clean() which gets output and cleans buffer.
 			// Get the response.
 			$response = json_decode( $this->_last_response, true );
 			$this->assertFalse( $response['success'] );

--- a/tests/phpunit/traits/test-class-ajax-security-base.php
+++ b/tests/phpunit/traits/test-class-ajax-security-base.php
@@ -102,11 +102,18 @@ class Ajax_Security_Base_Test extends \WP_Ajax_UnitTestCase {
 	public function test_verify_nonce_or_fail_invalid() {
 		$_REQUEST['nonce'] = 'invalid_nonce';
 
+		// WordPress Core's _handleAjax() starts output buffering before calling AJAX actions.
+		// We need to do the same since we're calling methods directly.
+		// WordPress Core's dieHandler() will call ob_get_clean() to clean this buffer.
+		\ini_set( 'implicit_flush', false );
+		\ob_start();
+
 		// WP_Ajax_UnitTestCase allows us to test AJAX methods that call wp_send_json_error().
 		try {
 			$this->mock_class->public_verify_nonce_or_fail();
 			$this->fail( 'Expected WPAjaxDieContinueException was not thrown' );
 		} catch ( \WPAjaxDieContinueException $e ) {
+			// WordPress Core's dieHandler() calls ob_get_clean() which gets output and cleans buffer.
 			// Get the response.
 			$response = json_decode( $this->_last_response, true );
 			$this->assertFalse( $response['success'] );
@@ -148,11 +155,18 @@ class Ajax_Security_Base_Test extends \WP_Ajax_UnitTestCase {
 		$user_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
 		\wp_set_current_user( $user_id );
 
+		// WordPress Core's _handleAjax() starts output buffering before calling AJAX actions.
+		// We need to do the same since we're calling methods directly.
+		// WordPress Core's dieHandler() will call ob_get_clean() to clean this buffer.
+		\ini_set( 'implicit_flush', false );
+		\ob_start();
+
 		// WP_Ajax_UnitTestCase allows us to test AJAX methods that call wp_send_json_error().
 		try {
 			$this->mock_class->public_verify_capability_or_fail();
 			$this->fail( 'Expected WPAjaxDieContinueException was not thrown' );
 		} catch ( \WPAjaxDieContinueException $e ) {
+			// WordPress Core's dieHandler() calls ob_get_clean() which gets output and cleans buffer.
 			// Get the response.
 			$response = json_decode( $this->_last_response, true );
 			$this->assertFalse( $response['success'] );

--- a/tests/phpunit/traits/test-class-ajax-security-base.php
+++ b/tests/phpunit/traits/test-class-ajax-security-base.php
@@ -105,7 +105,7 @@ class Ajax_Security_Base_Test extends \WP_Ajax_UnitTestCase {
 		// WordPress Core's _handleAjax() starts output buffering before calling AJAX actions.
 		// We need to do the same since we're calling methods directly.
 		// WordPress Core's dieHandler() will call ob_get_clean() to clean this buffer.
-		\ini_set( 'implicit_flush', false );
+		\ini_set( 'implicit_flush', false ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		\ob_start();
 
 		// WP_Ajax_UnitTestCase allows us to test AJAX methods that call wp_send_json_error().
@@ -158,7 +158,7 @@ class Ajax_Security_Base_Test extends \WP_Ajax_UnitTestCase {
 		// WordPress Core's _handleAjax() starts output buffering before calling AJAX actions.
 		// We need to do the same since we're calling methods directly.
 		// WordPress Core's dieHandler() will call ob_get_clean() to clean this buffer.
-		\ini_set( 'implicit_flush', false );
+		\ini_set( 'implicit_flush', false ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		\ob_start();
 
 		// WP_Ajax_UnitTestCase allows us to test AJAX methods that call wp_send_json_error().

--- a/tests/phpunit/traits/test-class-ajax-security-yoast.php
+++ b/tests/phpunit/traits/test-class-ajax-security-yoast.php
@@ -69,11 +69,18 @@ class Ajax_Security_Yoast_Test extends \WP_Ajax_UnitTestCase {
 		// Verify WPSEO_Options class doesn't exist.
 		$this->assertFalse( \class_exists( 'WPSEO_Options' ) );
 
+		// WordPress Core's _handleAjax() starts output buffering before calling AJAX actions.
+		// We need to do the same since we're calling methods directly.
+		// WordPress Core's dieHandler() will call ob_get_clean() to clean this buffer.
+		\ini_set( 'implicit_flush', false );
+		\ob_start();
+
 		// WP_Ajax_UnitTestCase allows us to test AJAX methods that call wp_send_json_error().
 		try {
 			$this->mock_class->public_verify_yoast_active_or_fail();
 			$this->fail( 'Expected WPAjaxDieContinueException was not thrown' );
 		} catch ( \WPAjaxDieContinueException $e ) {
+			// WordPress Core's dieHandler() calls ob_get_clean() which gets output and cleans buffer.
 			// Get the response.
 			$response = json_decode( $this->_last_response, true );
 			$this->assertFalse( $response['success'] );

--- a/tests/phpunit/traits/test-class-ajax-security-yoast.php
+++ b/tests/phpunit/traits/test-class-ajax-security-yoast.php
@@ -72,7 +72,7 @@ class Ajax_Security_Yoast_Test extends \WP_Ajax_UnitTestCase {
 		// WordPress Core's _handleAjax() starts output buffering before calling AJAX actions.
 		// We need to do the same since we're calling methods directly.
 		// WordPress Core's dieHandler() will call ob_get_clean() to clean this buffer.
-		\ini_set( 'implicit_flush', false );
+		\ini_set( 'implicit_flush', false ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		\ob_start();
 
 		// WP_Ajax_UnitTestCase allows us to test AJAX methods that call wp_send_json_error().


### PR DESCRIPTION
Fixes tests that are getting marked as risky in phpunit.
The issue was output buffering because Ajax responses internally call `wp_die()`