### PR TITLE
Dont include both file and it's fallback in the 'the_file"

### DIFF
--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -404,6 +404,7 @@ class Base {
 				if ( $get_contents ) {
 					return (string) \ob_get_clean();
 				}
+				break; // Exit the loop after the first file is found, covers the case when $get_contents is false.
 			}
 		}
 		return '';


### PR DESCRIPTION
We have a method similar to `get_template_part` function, it is used to include template files and optionally pass the arguments to the included file.

In case when the fallback template file is specified and `$get_contents` argument is set to to `false` both the template file and it's fallback will be included.

Popped up while working with interactive tasks and wanted to create specific template for the new such task, I got both new popover and fallback included from [the_popover_content](https://github.com/Emilia-Capital/progress-planner/blob/60c9dbb63bd541626d49075a68a8428684bedae1/classes/suggested-tasks/providers/class-tasks-interactive.php#L184-L198),