### PR TITLE
Register branded site earlier

### DIFF
--- a/classes/admin/widgets/class-challenge.php
+++ b/classes/admin/widgets/class-challenge.php
@@ -90,7 +90,7 @@ final class Challenge extends Widget {
 	public function get_remote_api_url() {
 		return \add_query_arg(
 			[
-				'license_key' => \get_option( 'progress_planner_license_key' ),
+				'license_key' => \progress_planner()->get_license_key(),
 				'site'        => \get_site_url(),
 			],
 			\progress_planner()->get_remote_server_root_url() . '/wp-json/progress-planner-saas/v1/challenges'

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -98,6 +98,14 @@ class Base {
 			$this->get_utils__playground();
 		}
 
+		$prpl_license_key = $this->get_license_key();
+		if ( ! $prpl_license_key && 0 !== (int) \progress_planner()->get_ui__branding()->get_branding_id() ) {
+			$prpl_license_key = \progress_planner()->get_utils__onboard()->make_remote_onboarding_request();
+			if ( '' !== $prpl_license_key ) {
+				\update_option( 'progress_planner_license_key', $prpl_license_key, false );
+			}
+		}
+
 		// Basic classes.
 		if ( \is_admin() && \current_user_can( 'edit_others_posts' ) ) {
 			$this->get_admin__page();
@@ -301,7 +309,16 @@ class Base {
 	 * @return bool
 	 */
 	public function is_privacy_policy_accepted() {
-		return false !== \get_option( 'progress_planner_license_key', false );
+		return false !== $this->get_license_key();
+	}
+
+	/**
+	 * Get the license key.
+	 *
+	 * @return string|false
+	 */
+	public function get_license_key() {
+		return \get_option( 'progress_planner_license_key', false );
 	}
 
 	/**

--- a/classes/class-lessons.php
+++ b/classes/class-lessons.php
@@ -57,7 +57,7 @@ class Lessons {
 		$url = \add_query_arg(
 			[
 				'site'        => \get_site_url(),
-				'license_key' => \get_option( 'progress_planner_license_key' ),
+				'license_key' => \progress_planner()->get_license_key(),
 			],
 			$url
 		);

--- a/classes/rest/class-base.php
+++ b/classes/rest/class-base.php
@@ -86,7 +86,7 @@ abstract class Base {
 			return true;
 		}
 
-		$license_key = \get_option( 'progress_planner_license_key', false );
+		$license_key = \progress_planner()->get_license_key();
 		if ( ! $license_key || 'no-license' === $license_key ) {
 			// Increment failed attempts counter.
 			\set_transient( $rate_limit_key, $failed_attempts + 1, HOUR_IN_SECONDS );

--- a/classes/utils/class-debug-tools.php
+++ b/classes/utils/class-debug-tools.php
@@ -515,7 +515,7 @@ class Debug_Tools {
 		);
 
 		// Free license info.
-		$prpl_free_license_key = \get_option( 'progress_planner_license_key', false );
+		$prpl_free_license_key = \progress_planner()->get_license_key();
 		$admin_bar->add_node(
 			[
 				'id'     => 'prpl-free-license',

--- a/classes/utils/class-onboard.php
+++ b/classes/utils/class-onboard.php
@@ -29,7 +29,7 @@ class Onboard {
 		// Detect domain changes.
 		\add_action( 'shutdown', [ $this, 'detect_site_url_changes' ] );
 
-		if ( \get_option( 'progress_planner_license_key' ) ) {
+		if ( \progress_planner()->get_license_key() ) {
 			return;
 		}
 
@@ -194,7 +194,7 @@ class Onboard {
 			return;
 		}
 
-		$saved_license_key = \get_option( 'progress_planner_license_key', false );
+		$saved_license_key = \progress_planner()->get_license_key();
 
 		// Bail early if the license key is not set, or if the site URL has not changed.
 		if ( ! $saved_license_key || $saved_site_url === $current_site_url ) {

--- a/classes/utils/class-playground.php
+++ b/classes/utils/class-playground.php
@@ -28,7 +28,7 @@ class Playground {
 	 * @return void
 	 */
 	public function register_hooks() {
-		if ( ! \get_option( 'progress_planner_license_key', false ) && ! \get_option( 'progress_planner_demo_data_generated', false ) ) {
+		if ( ! \progress_planner()->get_license_key() && ! \get_option( 'progress_planner_demo_data_generated', false ) ) {
 			$this->generate_data();
 			\update_option( 'progress_planner_license_key', \str_replace( ' ', '-', $this->create_random_string( 20 ) ) );
 			\update_option( 'progress_planner_force_show_onboarding', false );

--- a/tests/phpunit/test-class-api-get-stats.php
+++ b/tests/phpunit/test-class-api-get-stats.php
@@ -72,7 +72,7 @@ class Test_API_Get_Stats extends \WP_UnitTestCase {
 		$url = \add_query_arg(
 			[
 				'site'        => \get_site_url(),
-				'license_key' => \get_option( 'progress_planner_license_key' ),
+				'license_key' => \progress_planner()->get_license_key(),
 			],
 			$url
 		);

--- a/tests/phpunit/test-class-page-types.php
+++ b/tests/phpunit/test-class-page-types.php
@@ -73,7 +73,7 @@ class Page_Types_Test extends \WP_UnitTestCase {
 		$url = \add_query_arg(
 			[
 				'site'        => \get_site_url(),
-				'license_key' => \get_option( 'progress_planner_license_key' ),
+				'license_key' => \progress_planner()->get_license_key(),
 			],
 			$url
 		);

--- a/views/admin-page-header.php
+++ b/views/admin-page-header.php
@@ -25,7 +25,7 @@ if ( ! \defined( 'ABSPATH' ) ) {
 		<?php
 
 		// Render the subscribe form button and popover if the license key is not set.
-		if ( 'no-license' === \get_option( 'progress_planner_license_key', 'no-license' ) ) {
+		if ( 'no-license' === \progress_planner()->get_license_key() ) {
 			\progress_planner()->get_ui__popover()->the_popover( 'subscribe-form' )->render_button(
 				'',
 				\progress_planner()->get_asset( 'images/register_icon.svg' ) . '<span class="screen-reader-text">' . \esc_html__( 'Subscribe', 'progress-planner' ) . '</span>'

--- a/views/admin-page.php
+++ b/views/admin-page.php
@@ -11,14 +11,6 @@ if ( ! \defined( 'ABSPATH' ) ) {
 }
 
 $prpl_privacy_policy_accepted = \progress_planner()->is_privacy_policy_accepted();
-
-if ( 0 !== (int) \progress_planner()->get_ui__branding()->get_branding_id() ) {
-	$prpl_license_key = \progress_planner()->get_utils__onboard()->make_remote_onboarding_request();
-	if ( '' !== $prpl_license_key ) {
-		\update_option( 'progress_planner_license_key', $prpl_license_key );
-		$prpl_privacy_policy_accepted = true;
-	}
-}
 ?>
 
 <div class="wrap prpl-wrap <?php echo \esc_attr( $prpl_privacy_policy_accepted ? '' : 'prpl-pp-not-accepted' ); ?>">

--- a/views/welcome.php
+++ b/views/welcome.php
@@ -12,7 +12,7 @@ if ( ! \defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( false !== \get_option( 'progress_planner_license_key', false ) ) {
+if ( false !== \progress_planner()->get_license_key() ) {
 	return;
 }
 


### PR DESCRIPTION
Branded sites are registered automatically, that was done on the PP Dashboard page but it was done too late. 

Before loading assets we check if Privacy Policy is accepted, which is actually check [if license is saved](https://github.com/Emilia-Capital/progress-planner/blob/476c5cd210f04316e955317fbbaaae4a0b723d61/classes/class-base.php#L311-L313). Since the license was generated on the page itself, some assets are not enqueued which results in page not being rendered properly

<details><summary>screenshot</summary>
<img width="1564" height="922" alt="Screenshot 2025-12-15 at 15 45 48" src="https://github.com/user-attachments/assets/cc77bf62-1ffc-427a-a42d-be87c807444e" />
</details>

This PR moves the "auto registration" for branded installs earlier. Also before request to backend server was triggered on every page load, this PR also fixes that so the request is only fired if the license is not already saved.

This change is also necessary since new onboarding can be triggered on front end and on any other admin page, not just on PP Dashboard page.