### PR TITLE
New onboarding tweaks

### DIFF
--- a/assets/css/onboarding/onboarding.css
+++ b/assets/css/onboarding/onboarding.css
@@ -298,6 +298,7 @@
 		img, svg {
 			height: 100%;
 			width: auto;
+			max-width: 100%;
 		}
 	}
 

--- a/assets/js/onboarding/steps/SettingsStep.js
+++ b/assets/js/onboarding/steps/SettingsStep.js
@@ -1,18 +1,11 @@
 /**
- * Settings step - Configure About, Contact, FAQ pages, Post Types, and Login Destination
+ * Settings step - Configure About, Contact, FAQ pages, and Post Types
  * Multi-step process with 5 sub-steps
  */
 /* global OnboardingStep, ProgressPlannerOnboardData */
 
 class PrplSettingsStep extends OnboardingStep {
-	subSteps = [
-		'homepage',
-		'about',
-		'contact',
-		'faq',
-		'post-types',
-		'login-destination',
-	];
+	subSteps = [ 'homepage', 'about', 'contact', 'faq', 'post-types' ];
 
 	defaultSettings = {
 		homepage: {
@@ -33,9 +26,6 @@ class PrplSettingsStep extends OnboardingStep {
 		},
 		'post-types': {
 			selectedTypes: [], // Array of selected post type slugs
-		},
-		'login-destination': {
-			redirectOnLogin: false, // Checkbox state
 		},
 	};
 
@@ -137,7 +127,7 @@ class PrplSettingsStep extends OnboardingStep {
 
 	/**
 	 * Setup event listeners for a sub-step
-	 * @param {string} subStepName - Name of sub-step (about/contact/faq/post-types/login-destination)
+	 * @param {string} subStepName - Name of sub-step (about/contact/faq/post-types)
 	 * @param {Object} subStepData - Data for this sub-step
 	 * @param {Object} state       - Wizard state
 	 */
@@ -153,16 +143,6 @@ class PrplSettingsStep extends OnboardingStep {
 		// Handle post types sub-step
 		if ( subStepName === 'post-types' ) {
 			this.setupPostTypesListeners( subStepName, subStepData, state );
-			return;
-		}
-
-		// Handle login destination sub-step
-		if ( subStepName === 'login-destination' ) {
-			this.setupLoginDestinationListeners(
-				subStepName,
-				subStepData,
-				state
-			);
 		}
 	}
 
@@ -343,60 +323,6 @@ class PrplSettingsStep extends OnboardingStep {
 	}
 
 	/**
-	 * Setup event listeners for login destination sub-step
-	 * @param {string} subStepName - Name of sub-step
-	 * @param {Object} subStepData - Data for this sub-step
-	 * @param {Object} state       - Wizard state
-	 */
-	setupLoginDestinationListeners( subStepName, subStepData, state ) {
-		const container = this.popover.querySelector(
-			`.prpl-setting-item[data-page="${ subStepName }"]`
-		);
-		const saveButton = this.popover.querySelector(
-			`#prpl-save-${ subStepName }-setting`
-		);
-
-		if ( ! container || ! saveButton ) {
-			return;
-		}
-
-		// Get checkbox
-		const checkbox = container.querySelector(
-			'input[type="checkbox"][name="prpl-redirect-on-login"]'
-		);
-
-		if ( ! checkbox ) {
-			return;
-		}
-
-		// Initialize from checkbox that is already set in template, or from saved data
-		if ( subStepData.redirectOnLogin === undefined ) {
-			subStepData.redirectOnLogin = checkbox.checked;
-		} else {
-			checkbox.checked = subStepData.redirectOnLogin;
-		}
-
-		// Add change listener
-		checkbox.addEventListener( 'change', ( e ) => {
-			subStepData.redirectOnLogin = e.target.checked;
-			this.updateSaveButtonState( saveButton, subStepData );
-
-			// Update Next/Dashboard button if on last sub-step
-			if ( this.currentSubStep === this.subSteps.length - 1 ) {
-				this.updateNextButton();
-			}
-		} );
-
-		// Save button handler - just advances to next sub-step
-		saveButton.addEventListener( 'click', () => {
-			this.advanceSubStep( state );
-		} );
-
-		// Initial button state
-		this.updateSaveButtonState( saveButton, subStepData );
-	}
-
-	/**
 	 * Advance to next sub-step
 	 * @param {Object} state - Wizard state
 	 */
@@ -443,11 +369,6 @@ class PrplSettingsStep extends OnboardingStep {
 		// Handle post types sub-step - at least one must be selected
 		if ( subStepData.selectedTypes !== undefined ) {
 			return subStepData.selectedTypes.length > 0;
-		}
-
-		// Handle login destination sub-step - always valid (checkbox is optional)
-		if ( subStepData.redirectOnLogin !== undefined ) {
-			return true;
 		}
 
 		return false;
@@ -523,12 +444,6 @@ class PrplSettingsStep extends OnboardingStep {
 				postTypesData.selectedTypes.forEach( ( postType ) => {
 					formDataObj.append( 'prpl-post-types-include[]', postType );
 				} );
-			}
-
-			// Add login destination
-			const loginData = state.data.settings[ 'login-destination' ];
-			if ( loginData && loginData.redirectOnLogin ) {
-				formDataObj.append( 'prpl-redirect-on-login', '1' );
 			}
 
 			// Send single AJAX request

--- a/classes/class-plugin-upgrade-tasks.php
+++ b/classes/class-plugin-upgrade-tasks.php
@@ -83,8 +83,9 @@ class Plugin_Upgrade_Tasks {
 	 * @return void
 	 */
 	protected function add_initial_onboarding_tasks() {
-		// Privacy policy is not accepted, so it's a fresh install.
-		$fresh_install = ! \progress_planner()->is_privacy_policy_accepted();
+		// Check if this is a fresh install (not a re-activation).
+		// If the option doesn't exist, it's a fresh install.
+		$fresh_install = false === \get_option( 'progress_planner_previous_version_task_providers', false );
 
 		// If this is the first time the plugin is installed, save the task providers.
 		if ( $fresh_install ) {

--- a/views/onboarding/settings.php
+++ b/views/onboarding/settings.php
@@ -42,10 +42,7 @@ $prpl_page_types = [
 $prpl_saved_settings = \progress_planner()->get_settings()->get_post_types_names();
 $prpl_post_types     = \progress_planner()->get_settings()->get_public_post_types();
 
-// Get redirect on login setting.
-$prpl_redirect_on_login = \get_user_meta( \get_current_user_id(), 'prpl_redirect_on_login', true );
-
-$prpl_total_number_of_steps = 6;
+$prpl_total_number_of_steps = 5;
 $prpl_current_step_number   = 0;
 
 ?>
@@ -200,70 +197,6 @@ $prpl_current_step_number   = 0;
 				</div>
 			</div>
 		<?php endif; ?>
-
-		<!-- Login Destination sub-step -->
-		<?php ++$prpl_current_step_number; ?>
-		<div class="prpl-setting-item" data-page="login-destination">
-			<div class="prpl-columns-wrapper-flex">
-				<div class="prpl-column">
-					<div class="prpl-background-content">
-						<p><?php echo \esc_html( $prpl_page_type['description'] ); ?></p>
-					</div>
-				</div>
-				<div class="prpl-column">
-					<div class="prpl-setting-header">
-						<h3 class="prpl-setting-title">
-							<?php \esc_html_e( 'Settings:', 'progress-planner' ); ?> <?php \esc_html_e( 'Default login destination', 'progress-planner' ); ?>
-							<span class="prpl-settings-progress"><?php echo \esc_html( $prpl_current_step_number ); ?>/<?php echo \esc_html( $prpl_total_number_of_steps ); ?></span>
-						</h3>
-						<p>
-							<?php
-							/* translators: %s: Progress Planner name. */
-							\printf( \esc_html__( 'Do you want to land on the %s dashboard after logging in? So you can start improving your site straight away!', 'progress-planner' ), \esc_html( \progress_planner()->get_ui__branding()->get_admin_menu_name() ) );
-							?>
-						</p>
-					</div>
-
-					<div class="prpl-setting-content">
-						<div class="prpl-settings-wrapper">
-							<p>
-								<?php \esc_html_e( 'Where do you want to start when you login to your site?', 'progress-planner' ); ?>
-							</p>
-
-							<?php
-							\progress_planner()->the_view(
-								'onboarding/form-inputs/checkbox.php',
-								[
-									'name'          => 'redirect_on_login',
-									'current_value' => '',
-									'options'       => [
-										[
-											'id'    => 'prpl-setting-redirect-on-login',
-											'label' => \sprintf(
-												/* translators: %s: Progress Planner name. */
-												\esc_html__( 'Show the %s dashboard after login.', 'progress-planner' ),
-												\esc_html( \progress_planner()->get_ui__branding()->get_admin_menu_name() )
-											),
-											'value' => '1',
-										],
-									],
-								]
-							);
-							?>
-						</div>
-					</div>
-					<div class="prpl-setting-footer">
-						<button
-							type="button"
-							id="prpl-save-login-destination-setting"
-							class="prpl-btn prpl-save-setting-btn"
-						>
-							<?php \esc_html_e( 'Save setting', 'progress-planner' ); ?>
-						</button>
-					</div>
-				</div>
-			</div>
-		</div>
 	</div>
 	<div class="tour-footer">
 		<div class="prpl-tour-next-wrapper">


### PR DESCRIPTION
This PR:

- Removes "Default login destination" checkbox from onboarding, since we removed that option in https://github.com/ProgressPlanner/progress-planner/pull/702
- Adds `max-width` to onboarding logo, to prevent horizontal overflow
- Changes condition for when Upgrading tasks should be displayed, since we changed when privacy policy was accepted for branded instances in https://github.com/ProgressPlanner/progress-planner/pull/726