### PR TITLE
Reverse logic for "Show Onboarding" filter

### DIFF
--- a/classes/class-onboard-wizard.php
+++ b/classes/class-onboard-wizard.php
@@ -50,8 +50,8 @@ class Onboard_Wizard {
 		// 1. Privacy not yet accepted (new install, non-branded).
 		// 2. Onboarding already in progress.
 		// 3. Branded site (privacy auto-accepted, but still needs onboarding).
-		$is_branded       = 0 !== (int) \progress_planner()->get_ui__branding()->get_branding_id();
-		$show_onboarding  = ! \progress_planner()->is_privacy_policy_accepted()
+		$is_branded      = 0 !== (int) \progress_planner()->get_ui__branding()->get_branding_id();
+		$show_onboarding = ! \progress_planner()->is_privacy_policy_accepted()
 			|| \get_option( 'prpl_onboard_progress', false )
 			|| $is_branded;
 

--- a/classes/class-onboard-wizard.php
+++ b/classes/class-onboard-wizard.php
@@ -50,22 +50,22 @@ class Onboard_Wizard {
 		// 1. Privacy not yet accepted (new install, non-branded).
 		// 2. Onboarding already in progress.
 		// 3. Branded site (privacy auto-accepted, but still needs onboarding).
-		$is_branded      = 0 !== (int) \progress_planner()->get_ui__branding()->get_branding_id();
-		$skip_onboarding = \progress_planner()->is_privacy_policy_accepted()
-			&& ! \get_option( 'prpl_onboard_progress', false )
-			&& ! $is_branded;
+		$is_branded       = 0 !== (int) \progress_planner()->get_ui__branding()->get_branding_id();
+		$show_onboarding  = ! \progress_planner()->is_privacy_policy_accepted()
+			|| \get_option( 'prpl_onboard_progress', false )
+			|| $is_branded;
 
 		/**
-		 * Filter whether to skip the onboarding wizard.
+		 * Filter whether to show the onboarding wizard.
 		 *
 		 * Hosting integrations can use this filter to force showing
 		 * or hiding the onboarding wizard.
 		 *
-		 * @param bool $skip_onboarding Whether to skip showing the onboarding wizard.
+		 * @param bool $show_onboarding Whether to show the onboarding wizard.
 		 */
-		$skip_onboarding = \apply_filters( 'progress_planner_skip_onboarding', $skip_onboarding );
+		$show_onboarding = \apply_filters( 'progress_planner_show_onboarding', $show_onboarding );
 
-		if ( $skip_onboarding ) {
+		if ( ! $show_onboarding ) {
 			return;
 		}
 

--- a/tests/phpunit/test-class-onboard-wizard.php
+++ b/tests/phpunit/test-class-onboard-wizard.php
@@ -336,30 +336,30 @@ class Onboard_Wizard_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test skip_onboarding filter.
+	 * Test show_onboarding filter.
 	 *
 	 * @return void
 	 */
-	public function test_skip_onboarding_filter() {
+	public function test_show_onboarding_filter() {
 		// Set admin user.
 		\wp_set_current_user( $this->admin_user_id );
 
 		// Ensure privacy is not accepted (would normally show onboarding).
 		\delete_option( 'progress_planner_license_key' );
 
-		// Add filter to skip onboarding.
-		\add_filter( 'progress_planner_skip_onboarding', '__return_true' );
+		// Add filter to hide onboarding.
+		\add_filter( 'progress_planner_show_onboarding', '__return_false' );
 
 		$wizard = new Onboard_Wizard();
 		$wizard->maybe_register_popover_hooks();
 
-		// Footer hooks should NOT be registered when filter skips onboarding.
+		// Footer hooks should NOT be registered when filter hides onboarding.
 		$this->assertFalse(
 			\has_action( 'wp_footer', [ $wizard, 'add_popover' ] )
 		);
 
 		// Remove filter.
-		\remove_filter( 'progress_planner_skip_onboarding', '__return_true' );
+		\remove_filter( 'progress_planner_show_onboarding', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
This filter was added as part of the new Onboarding, to allow other plugins (like pp-hosts) to change when the onboarding should be displayed (by default it is shown on first (front or back end) page load after the plugin is installed).

Condition was set to filtered value was "should onboarding be skipped", but I think it is more clear to filter "should onboarding be displayed" value - so this PR just reverses that.