### PR TITLE
Exclude direct_file_access check from plugin-check

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -26,7 +26,7 @@ jobs:
             unzip ${{ github.event.repository.name }}.zip -d build
 
         - name: Run plugin check
-          uses: wordpress/plugin-check-action@v1.0.6
+          uses: wordpress/plugin-check-action@v1.1.4
           with:
             build-dir: './build/${{ github.event.repository.name }}'
             exclude-checks: |

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -29,3 +29,5 @@ jobs:
           uses: wordpress/plugin-check-action@v1.0.6
           with:
             build-dir: './build/${{ github.event.repository.name }}'
+            exclude-checks: |
+              direct_file_access


### PR DESCRIPTION
## Summary

- Excludes the `direct_file_access` check from the WordPress.org Plugin Check workflow

## Why

Plugin Check 1.8.0 (released Dec 27, 2025) added a new check requiring ABSPATH constant in all PHP files. This affects 164 class files that use namespaces and autoloading and makes the test fail for every PR.

This check didn't exist when the workflow was introduced, so excluding it to restore previous behavior. Can be re-enabled if we decide to add the ABSPATH check to all files.