### PR TITLE
Remove custom positioning for "Interactive task" popover

### DIFF
--- a/assets/js/web-components/prpl-interactive-task.js
+++ b/assets/js/web-components/prpl-interactive-task.js
@@ -5,14 +5,6 @@
  */
 // eslint-disable-next-line no-unused-vars
 class PrplInteractiveTask extends HTMLElement {
-	// eslint-disable-next-line no-useless-constructor
-	constructor() {
-		// Get parent class properties
-		super();
-
-		this.repositionPopover = this.repositionPopover.bind( this ); // So this is available in the event listener.
-	}
-
 	/**
 	 * Runs when the component is added to the DOM.
 	 */
@@ -56,20 +48,6 @@ class PrplInteractiveTask extends HTMLElement {
 	}
 
 	/**
-	 * Runs when the popover is added to the DOM.
-	 */
-	popoverAddedToDOM() {
-		window.addEventListener( 'resize', this.repositionPopover );
-	}
-
-	/**
-	 * Runs when the popover is opening.
-	 */
-	popoverOpening() {
-		this.repositionPopover();
-	}
-
-	/**
 	 * Runs when the popover is closing.
 	 */
 	popoverClosing() {}
@@ -106,63 +84,6 @@ class PrplInteractiveTask extends HTMLElement {
 		const popoverId = this.getAttribute( 'popover-id' );
 		const popover = document.getElementById( popoverId );
 		popover.hidePopover();
-	}
-
-	/**
-	 * Repositions the popover relative to the target element.
-	 * @private
-	 */
-	repositionPopover() {
-		const horizontalTarget = document.querySelector( '.prpl-wrap' );
-		const verticalTarget = document.querySelector(
-			'.prpl-widget-wrapper.prpl-suggested-tasks'
-		);
-
-		// Just in case.
-		if ( ! horizontalTarget || ! verticalTarget ) {
-			return;
-		}
-
-		const horizontalRect = horizontalTarget.getBoundingClientRect();
-		const verticalRect = verticalTarget.getBoundingClientRect();
-		const popoverId = this.getAttribute( 'popover-id' );
-		const popover = document.getElementById( popoverId );
-
-		// Reset default popover styles.
-		popover.style.margin = '0';
-
-		// Calculate target's center
-		const horizontalTargetCenter =
-			horizontalRect.left + horizontalRect.width / 2;
-
-		// Ensure that the popover is not too far from the top of the screen on small screens.
-		const MARGIN_TOP = 12; // minimum gap from top
-		const MARGIN_BOTTOM = 12; // minimum gap from bottom
-		const MOBILE_TOP_CAP = 100; // max starting offset on small screens
-		const isSmallScreen = window.matchMedia( '(max-width: 768px)' ).matches;
-		const MAX_TOP_CAP = isSmallScreen
-			? MOBILE_TOP_CAP
-			: Number.POSITIVE_INFINITY;
-
-		const desiredTop = Math.round( verticalRect.top );
-
-		const clampedTop = Math.max(
-			MARGIN_TOP,
-			Math.min( desiredTop, MAX_TOP_CAP )
-		);
-
-		// Apply the position.
-		popover.style.position = 'fixed';
-		popover.style.left = `${ horizontalTargetCenter }px`;
-		popover.style.top = `${ Math.round( clampedTop ) }px`;
-		popover.style.transform = 'translateX(-50%)';
-
-		// Make sure popover content can scroll if needed
-		popover.style.maxHeight = '80vh'; // adjustable
-		popover.style.overflowY = 'auto';
-		popover.style.maxHeight = `calc(100vh - ${
-			clampedTop + MARGIN_BOTTOM
-		}px)`;
 	}
 }
 


### PR DESCRIPTION
This PR removes the custom positioning we had for the "Interactive" popover.

By default we popover is positioned at the center of the screen, but a while back we decided to position it so it's top border is aligned with the top border of the Recommendations widget. 

This is no longer needed for 2 reasons:

- When we have added it Recommendations widget only 3-4 recommendations displayed, now user can load more tasks so it is weird to display popover at the top of the widget if user clicks on the recommendation which is close to the end of the list.
- We are in the middle of the React refactoring and popovers and their positioning work differently in that implementation.
