### PR TITLE
Add null guards to prevent fatal errors during pp-hosts plugin updates

### DIFF
--- a/classes/actions/class-content-scan.php
+++ b/classes/actions/class-content-scan.php
@@ -59,12 +59,18 @@ class Content_Scan extends Content {
 			return;
 		}
 
+		// Bail if content helpers are not available (can happen during plugin updates).
+		$content_helpers = \progress_planner()->get_activities__content_helpers();
+		if ( null === $content_helpers ) {
+			return;
+		}
+
 		// Get posts.
 		$posts = \get_posts(
 			[
 				'posts_per_page' => static::SCAN_POSTS_PER_PAGE,
 				'paged'          => $current_page,
-				'post_type'      => \progress_planner()->get_activities__content_helpers()->get_post_types_names(),
+				'post_type'      => $content_helpers->get_post_types_names(),
 				'post_status'    => 'publish',
 			]
 		);
@@ -88,9 +94,15 @@ class Content_Scan extends Content {
 	 * @return int
 	 */
 	public function get_total_pages() {
+		// Bail if content helpers are not available (can happen during plugin updates).
+		$content_helpers = \progress_planner()->get_activities__content_helpers();
+		if ( null === $content_helpers ) {
+			return 0;
+		}
+
 		// Get the total number of posts.
 		$total_posts_count = 0;
-		foreach ( \progress_planner()->get_activities__content_helpers()->get_post_types_names() as $post_type ) {
+		foreach ( $content_helpers->get_post_types_names() as $post_type ) {
 			$total_posts_count += \wp_count_posts( $post_type )->publish;
 		}
 		// Calculate the total pages to scan.

--- a/classes/actions/class-content.php
+++ b/classes/actions/class-content.php
@@ -157,10 +157,16 @@ class Content {
 	 * @return bool
 	 */
 	private function should_skip_saving( $post ) {
+		// Bail if content helpers are not available (can happen during plugin updates).
+		$content_helpers = \progress_planner()->get_activities__content_helpers();
+		if ( null === $content_helpers ) {
+			return true;
+		}
+
 		// Bail if the post is not included in the post-types we're tracking.
 		if ( ! \in_array(
 			$post->post_type,
-			\progress_planner()->get_activities__content_helpers()->get_post_types_names(),
+			$content_helpers->get_post_types_names(),
 			true
 		) ) {
 			return true;

--- a/classes/actions/class-maintenance.php
+++ b/classes/actions/class-maintenance.php
@@ -128,6 +128,11 @@ class Maintenance {
 	 * @return void
 	 */
 	protected function create_maintenance_activity( $type ) {
+		// Bail if the class doesn't exist (can happen during plugin updates).
+		if ( ! \class_exists( Activities_Maintenance::class ) ) {
+			return;
+		}
+
 		$activity       = new Activities_Maintenance();
 		$activity->type = $type;
 		$activity->save();

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -51,7 +51,7 @@ use Progress_Planner\Utils\Deprecations;
  * @method \Progress_Planner\UI\Popover get_ui__popover()
  * @method \Progress_Planner\Admin\Widgets\Content_Activity get_admin__widgets__content_activity()
  * @method \Progress_Planner\UI\Chart get_ui__chart()
- * @method \Progress_Planner\Activities\Content_Helpers get_activities__content_helpers()
+ * @method \Progress_Planner\Activities\Content_Helpers|null get_activities__content_helpers()
  * @method \Progress_Planner\Admin\Widgets\Challenge get_admin__widgets__challenge()
  * @method \Progress_Planner\Admin\Widgets\Activity_Scores get_admin__widgets__activity_scores()
  * @method \Progress_Planner\Utils\Date get_utils__date()


### PR DESCRIPTION
When pp-hosts (or other host plugins bundling Progress Planner) is updated, hooks registered by the old plugin version can fire during the update process. At that point, dependencies may not be available because files are being extracted, causing fatal errors like:
  - `Call to a member function get_post_types_names() on null`
  - `Class "Progress_Planner\Activities\Maintenance" not found`

This PR fixes that by adding checks and making early exits:

- Add null check for `get_activities__content_helpers()` in Content class `should_skip_saving()` method
- Add null checks in Content_Scan class `get_total_pages()` and `update_stats()` methods
- Add `class_exists()` check in Maintenance class before instantiating `Activities_Maintenance`


