### PR TITLE
Fix interactive task form resubmission after error and improve task completion check

### DIFF
--- a/assets/js/recommendations/interactive-task.js
+++ b/assets/js/recommendations/interactive-task.js
@@ -118,17 +118,25 @@ const prplInteractiveTaskFormListener = {
 				.finally( () => {
 					// Hide loading state.
 					prplInteractiveTaskFormListener.hideLoading( formElement );
-
-					// Remove the form listener once the callback is executed.
-					formElement.removeEventListener(
-						'submit',
-						formSubmitHandler
-					);
 				} );
 		};
 
 		// Add a form listener to the form.
 		formElement.addEventListener( 'submit', formSubmitHandler );
+
+		// Remove the form listener when the popover is closed.
+		document.getElementById( popoverId ).addEventListener(
+			'toggle',
+			( toggleEvent ) => {
+				if ( toggleEvent.newState === 'closed' ) {
+					formElement.removeEventListener(
+						'submit',
+						formSubmitHandler
+					);
+				}
+			},
+			{ once: true }
+		);
 	},
 
 	settings: ( {

--- a/classes/suggested-tasks/providers/class-set-valuable-post-types.php
+++ b/classes/suggested-tasks/providers/class-set-valuable-post-types.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Add tasks for settings saved.
+ * Add tasks for set valuable post types.
  *
  * @package Progress_Planner
  */
@@ -8,7 +8,7 @@
 namespace Progress_Planner\Suggested_Tasks\Providers;
 
 /**
- * Add tasks for settings saved.
+ * Add tasks for set valuable post types.
  */
 class Set_Valuable_Post_Types extends Tasks_Interactive {
 
@@ -119,21 +119,22 @@ class Set_Valuable_Post_Types extends Tasks_Interactive {
 
 	/**
 	 * Check if the task should be added.
-	 * We add tasks only to users who have have completed "Fill the settings page" task
-	 * and have upgraded from v1.2 or have 'include_post_types' option empty.
+	 * We add tasks only to users who have upgraded from v1.2 or have 'include_post_types' option empty.
 	 * Reason being that this option was migrated,
 	 * but it could be missed, and post type selection should be revisited.
 	 *
 	 * @return bool
 	 */
 	public function should_add_task() {
-		$saved_posts = \progress_planner()->get_suggested_tasks_db()->get_tasks_by( [ 'provider_id' => 'settings-saved' ] );
-		if ( empty( $saved_posts ) ) {
+		$activity = \progress_planner()->get_activities__query()->query_activities(
+			[
+				'category' => 'suggested_task',
+				'data_id'  => static::PROVIDER_ID,
+			]
+		);
+		if ( ! empty( $activity ) ) {
 			return false;
 		}
-
-		// Is the task trashed?
-		$post_trashed = 'trash' === $saved_posts[0]->post_status;
 
 		// Upgraded from <= 1.2?
 		$upgraded = (bool) \get_option( 'progress_planner_set_valuable_post_types', false );
@@ -141,8 +142,8 @@ class Set_Valuable_Post_Types extends Tasks_Interactive {
 		// Include post types option empty?
 		$include_post_types = \progress_planner()->get_settings()->get( 'include_post_types', [] );
 
-		// Add the task only to users who have completed the "Settings saved" task and have upgraded from v1.2 or have 'include_post_types' option empty.
-		return $post_trashed && ( true === $upgraded || empty( $include_post_types ) );
+		// Add the task only to users who have upgraded from v1.2 or have 'include_post_types' option empty.
+		return ( true === $upgraded || empty( $include_post_types ) );
 	}
 
 	/**


### PR DESCRIPTION
**Interactive task form listener** (assets/js/recommendations/interactive-task.js)

  - Moved form listener removal from finally block to popover toggle event
  - Previously, the listener was removed after every submission attempt, preventing users from resubmitting after an error
  - Now the listener is removed only when the popover closes

  **Set valuable post types provider** (classes/suggested-tasks/providers/class-set-valuable-post-types.php)

  - Changed should_add_task() to check activities table instead of task post existence
  - Aligns with the pattern used by set-date-format, select-timezone, and select-locale providers
  - Activities are a more reliable source of truth as they persist even if task posts are deleted