### PR TITLE
Correct "content" badges heading in the badges popover

### DIFF
--- a/assets/js/editor.js
+++ b/assets/js/editor.js
@@ -144,7 +144,7 @@ const PrplRenderPageTypeSelector = () => {
  * Render the video section.
  * This will display a button to open a modal with the video.
  *
- * @param {Object} props Component props.
+ * @param {Object} props               Component props.
  * @param {Object} props.lessonSection The lesson section.
  * @return {Element} Element to render.
  */

--- a/views/popovers/monthly-badges.php
+++ b/views/popovers/monthly-badges.php
@@ -39,7 +39,7 @@ if ( ! \defined( 'ABSPATH' ) ) {
 	<div class="prpl-popover-column">
 		<?php
 		$prpl_badges_groups = [
-			'content'     => \__( 'Writing badges', 'progress-planner' ),
+			'content'     => \__( 'Content badges', 'progress-planner' ),
 			'maintenance' => \__( 'Streak badges', 'progress-planner' ),
 		];
 		?>


### PR DESCRIPTION
The title in the popover should be consistent with the "Your content badges" title, which is used in the PP dashboard widget.

Related issue: https://github.com/ProgressPlanner/progress-planner-pro/issues/197