### PR TITLE
Fix header logo sizing and baseline gap

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -217,7 +217,11 @@ button.prpl-info-icon {
 	align-items: center;
 
 	.prpl-header-logo img {
-		height: 100px;
+		max-width: 300px;
+		max-height: 100px;
+		width: auto;
+		height: auto;
+		vertical-align: bottom;
 	}
 }
 


### PR DESCRIPTION
SVG logo files, which are used for branded sites with using `<img>` tag, were missing width and height attributes, causing them to have no intrinsic dimensions. This meant the browser couldn't determine their natural size, requiring explicit CSS height to display them at all.                                                                                                                                                      

Our solution was to add use `height: 100px;`, but this created gaps in case SVG had smaller height (we also have `max-width: 300px;` applied, so "landscape" logos had the gap).

Additionally, the logo container was slightly taller than the image due to the default inline image alignment sitting on the text baseline, which reserves space for letters like g, y, p.
                                                                                                                                                                                                 
This PR fixes that problem by adding:
  - width and height attributes to logo SVG files, giving them proper intrinsic dimensions (I have done this manually on the server)
  - CSS to use max-width and max-height as constraints while allowing the images to display at their natural size
  - vertical-align: bottom to eliminate the baseline gap
  
In case a custom dimensions need to be applied for specific brand, we can use it's Custom CSS field on the server side.