### PR TITLE
Add locale param to lesson tests

### DIFF
--- a/tests/phpunit/test-class-page-types.php
+++ b/tests/phpunit/test-class-page-types.php
@@ -74,6 +74,7 @@ class Page_Types_Test extends \WP_UnitTestCase {
 			[
 				'site'        => \get_site_url(),
 				'license_key' => \progress_planner()->get_license_key(),
+				'locale'      => apply_filters( 'prpl_lesson_locale', \get_locale() ),
 			],
 			$url
 		);


### PR DESCRIPTION
The locale param was added in this [commit](https://github.com/ProgressPlanner/progress-planner/commit/d0d3bd067633a4ef88da75b6debef2672d8b3df3), but tests were not updated and lessons were cached wrongly there.

This PR fixes that. 