### PR TITLE
Show 3 suggested tasks on WP Dashboard

### DIFF
--- a/classes/admin/class-enqueue.php
+++ b/classes/admin/class-enqueue.php
@@ -227,7 +227,7 @@ class Enqueue {
 
 				// Check if user wants to see all recommendations.
 				$show_all_recommendations = isset( $_GET['prpl_show_all_recommendations'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				$tasks_per_page           = $show_all_recommendations ? -1 : \Progress_Planner\Admin\Widgets\Suggested_Tasks::PER_PAGE_DEFAULT;
+				$tasks_per_page           = $show_all_recommendations ? -1 : \Progress_Planner\Admin\Widgets\Suggested_Tasks::get_per_page();
 
 				// Get tasks from task providers (limited to 5 by default, or unlimited if showing all).
 				$tasks = \progress_planner()->get_suggested_tasks()->get_tasks_in_rest_format(
@@ -269,7 +269,7 @@ class Enqueue {
 						],
 						'delayCelebration' => $delay_celebration,
 						'tasksPerPage'     => $tasks_per_page,
-						'perPageDefault'   => \Progress_Planner\Admin\Widgets\Suggested_Tasks::PER_PAGE_DEFAULT,
+						'perPageDefault'   => \Progress_Planner\Admin\Widgets\Suggested_Tasks::get_per_page(),
 					],
 				];
 				break;

--- a/classes/admin/widgets/class-suggested-tasks.php
+++ b/classes/admin/widgets/class-suggested-tasks.php
@@ -20,6 +20,26 @@ final class Suggested_Tasks extends Widget {
 	public const PER_PAGE_DEFAULT = 5;
 
 	/**
+	 * Number of tasks to show per page on the WP Dashboard.
+	 *
+	 * @var int
+	 */
+	public const PER_PAGE_DASHBOARD = 3;
+
+	/**
+	 * Get the number of tasks to show per page based on the current screen.
+	 *
+	 * @return int
+	 */
+	public static function get_per_page() {
+		$screen = \get_current_screen();
+		if ( $screen && 'dashboard' === $screen->id ) {
+			return self::PER_PAGE_DASHBOARD;
+		}
+		return self::PER_PAGE_DEFAULT;
+	}
+
+	/**
 	 * The widget ID.
 	 *
 	 * @var string


### PR DESCRIPTION
## Summary
- Add `get_per_page()` helper method to `Suggested_Tasks` widget
- Returns 3 tasks on the WP Dashboard screen, 5 on all other screens
- Replaces direct constant reference in `class-enqueue.php`

## Test plan
- [ ] Visit WP Dashboard — suggested tasks widget shows 3 tasks
- [ ] Visit Progress Planner page — suggested tasks shows 5 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)