### PR TITLE
Add year-specific monthly badge names with 2026 names

### DIFF
--- a/classes/badges/class-monthly.php
+++ b/classes/badges/class-monthly.php
@@ -148,14 +148,19 @@ final class Monthly extends Badge {
 	/**
 	 * Get an array of months.
 	 *
+	 * Year-specific names are supported. If no names are defined for the
+	 * given year, the default (2025) names are returned as a fallback.
+	 *
+	 * @param int|null $year The year. Null returns the default names.
+	 *
 	 * @return array
 	 */
-	public static function get_months() {
+	public static function get_months( $year = null ) {
 		/*
 		 * Indexed months, The array keys are prefixed with an "m"
 		 * so that they are strings and not integers.
 		 */
-		$months = [
+		$default = [
 			'm1'  => 'Jack January',
 			'm2'  => 'Felix February',
 			'm3'  => 'Mary March',
@@ -169,7 +174,29 @@ final class Monthly extends Badge {
 			'm11' => 'Noah November',
 			'm12' => 'Daisy December',
 		];
-		return $months;
+
+		$yearly = [
+			2026 => [
+				'm1'  => 'Jamie January',
+				'm2'  => 'Freya February',
+				'm3'  => 'Milo March',
+				'm4'  => 'Aida April',
+				'm5'  => 'Maeve May',
+				'm6'  => 'Jason June',
+				'm7'  => 'Julia July',
+				'm8'  => 'Ava August',
+				'm9'  => 'Sophie September',
+				'm10' => 'Omar October',
+				'm11' => 'Nathan November',
+				'm12' => 'Daniel December',
+			],
+		];
+
+		if ( null !== $year && isset( $yearly[ $year ] ) ) {
+			return $yearly[ $year ];
+		}
+
+		return $default;
 	}
 
 	/**
@@ -179,7 +206,7 @@ final class Monthly extends Badge {
 	 */
 	public function get_name() {
 		return $this->id
-			? self::get_months()[ 'm' . $this->get_month() ]
+			? self::get_months( (int) $this->get_year() )[ 'm' . $this->get_month() ]
 			: '';
 	}
 
@@ -229,8 +256,8 @@ final class Monthly extends Badge {
 			return $saved_progress;
 		}
 
-		$month     = self::get_months()[ 'm' . $this->get_month() ];
 		$year      = $this->get_year();
+		$month     = self::get_months( (int) $year )[ 'm' . $this->get_month() ];
 		$month_num = (int) $this->get_month();
 
 		$start_date = \DateTime::createFromFormat( 'Y-m-d', "{$year}-{$month_num}-01" );


### PR DESCRIPTION
Addresses https://github.com/ProgressPlanner/progress-planner-pro/issues/201 (item 3: badges per year)

## Summary
- `get_badge_name` now accepts an optional `$year` parameter to return year-specific badge names
- Adds 2026 badge names (Jamie January, Freya February, etc.)
- Default/2025 names are used as fallback when no year-specific names are defined
- To add future years, just add an entry to the `yearly_names` array

## Test plan
- [ ] Verify 2025 badges still show original names (Jack January, etc.)
- [ ] Verify 2026 badges show new names (Jamie January, etc.)
- [ ] Verify years without specific names fall back to defaults