### PR TITLE
Add LiteSpeed Cache integration with interactive tasks

### DIFF
--- a/assets/js/recommendations/litespeed-cache-browser-cache.js
+++ b/assets/js/recommendations/litespeed-cache-browser-cache.js
@@ -1,0 +1,32 @@
+/* global prplInteractiveTaskFormListener, progressPlanner */
+
+/*
+ * LiteSpeed Cache: enable browser cache.
+ *
+ * Dependencies: progress-planner/recommendations/interactive-task
+ */
+
+prplInteractiveTaskFormListener.customSubmit( {
+	taskId: 'litespeed-cache-browser-cache',
+	popoverId: 'prpl-popover-litespeed-cache-browser-cache',
+	callback: () => {
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_litespeed-cache-browser-cache',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
+		} );
+	},
+} );

--- a/assets/js/recommendations/litespeed-cache-css-minification.js
+++ b/assets/js/recommendations/litespeed-cache-css-minification.js
@@ -1,0 +1,32 @@
+/* global prplInteractiveTaskFormListener, progressPlanner */
+
+/*
+ * LiteSpeed Cache: enable CSS minification.
+ *
+ * Dependencies: progress-planner/recommendations/interactive-task
+ */
+
+prplInteractiveTaskFormListener.customSubmit( {
+	taskId: 'litespeed-cache-css-minification',
+	popoverId: 'prpl-popover-litespeed-cache-css-minification',
+	callback: () => {
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_litespeed-cache-css-minification',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
+		} );
+	},
+} );

--- a/assets/js/recommendations/litespeed-cache-guest-mode.js
+++ b/assets/js/recommendations/litespeed-cache-guest-mode.js
@@ -1,0 +1,32 @@
+/* global prplInteractiveTaskFormListener, progressPlanner */
+
+/*
+ * LiteSpeed Cache: enable guest mode.
+ *
+ * Dependencies: progress-planner/recommendations/interactive-task
+ */
+
+prplInteractiveTaskFormListener.customSubmit( {
+	taskId: 'litespeed-cache-guest-mode',
+	popoverId: 'prpl-popover-litespeed-cache-guest-mode',
+	callback: () => {
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_litespeed-cache-guest-mode',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
+		} );
+	},
+} );

--- a/assets/js/recommendations/litespeed-cache-image-lazy-load.js
+++ b/assets/js/recommendations/litespeed-cache-image-lazy-load.js
@@ -1,0 +1,32 @@
+/* global prplInteractiveTaskFormListener, progressPlanner */
+
+/*
+ * LiteSpeed Cache: enable image lazy loading.
+ *
+ * Dependencies: progress-planner/recommendations/interactive-task
+ */
+
+prplInteractiveTaskFormListener.customSubmit( {
+	taskId: 'litespeed-cache-image-lazy-load',
+	popoverId: 'prpl-popover-litespeed-cache-image-lazy-load',
+	callback: () => {
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_litespeed-cache-image-lazy-load',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
+		} );
+	},
+} );

--- a/assets/js/recommendations/litespeed-cache-js-minification.js
+++ b/assets/js/recommendations/litespeed-cache-js-minification.js
@@ -1,0 +1,32 @@
+/* global prplInteractiveTaskFormListener, progressPlanner */
+
+/*
+ * LiteSpeed Cache: enable JS minification.
+ *
+ * Dependencies: progress-planner/recommendations/interactive-task
+ */
+
+prplInteractiveTaskFormListener.customSubmit( {
+	taskId: 'litespeed-cache-js-minification',
+	popoverId: 'prpl-popover-litespeed-cache-js-minification',
+	callback: () => {
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_litespeed-cache-js-minification',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
+		} );
+	},
+} );

--- a/assets/js/recommendations/litespeed-cache-page-cache.js
+++ b/assets/js/recommendations/litespeed-cache-page-cache.js
@@ -1,0 +1,32 @@
+/* global prplInteractiveTaskFormListener, progressPlanner */
+
+/*
+ * LiteSpeed Cache: enable page cache.
+ *
+ * Dependencies: progress-planner/recommendations/interactive-task
+ */
+
+prplInteractiveTaskFormListener.customSubmit( {
+	taskId: 'litespeed-cache-page-cache',
+	popoverId: 'prpl-popover-litespeed-cache-page-cache',
+	callback: () => {
+		return new Promise( ( resolve, reject ) => {
+			fetch( progressPlanner.ajaxUrl, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+				body: new URLSearchParams( {
+					action: 'prpl_interactive_task_submit_litespeed-cache-page-cache',
+					nonce: progressPlanner.nonce,
+				} ),
+			} )
+				.then( ( response ) => {
+					resolve( { response, success: true } );
+				} )
+				.catch( ( error ) => {
+					reject( { success: false, error } );
+				} );
+		} );
+	},
+} );

--- a/classes/suggested-tasks/class-tasks-manager.php
+++ b/classes/suggested-tasks/class-tasks-manager.php
@@ -25,6 +25,7 @@ use Progress_Planner\Suggested_Tasks\Providers\Search_Engine_Visibility;
 use Progress_Planner\Suggested_Tasks\Tasks_Interface;
 use Progress_Planner\Suggested_Tasks\Providers\Integrations\Yoast\Add_Yoast_Providers;
 use Progress_Planner\Suggested_Tasks\Providers\Integrations\AIOSEO\Add_AIOSEO_Providers;
+use Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache\Add_Litespeed_Cache_Providers;
 use Progress_Planner\Suggested_Tasks\Providers\User as User_Tasks;
 use Progress_Planner\Suggested_Tasks\Providers\Email_Sending;
 use Progress_Planner\Suggested_Tasks\Providers\Set_Valuable_Post_Types;
@@ -119,6 +120,9 @@ class Tasks_Manager {
 
 		// All in One SEO integration.
 		new Add_AIOSEO_Providers();
+
+		// LiteSpeed Cache integration.
+		new Add_Litespeed_Cache_Providers();
 	}
 
 	/**

--- a/classes/suggested-tasks/providers/integrations/litespeed-cache/class-add-litespeed-cache-providers.php
+++ b/classes/suggested-tasks/providers/integrations/litespeed-cache/class-add-litespeed-cache-providers.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Class to add the LiteSpeed Cache providers.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache;
+
+/**
+ * Add tasks for LiteSpeed Cache configuration.
+ */
+class Add_Litespeed_Cache_Providers {
+
+	/**
+	 * Providers.
+	 *
+	 * @var \Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache\Litespeed_Cache_Interactive_Provider[]
+	 */
+	protected $providers = [];
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( \defined( 'LSCWP_V' ) ) {
+			\add_filter( 'progress_planner_suggested_tasks_providers', [ $this, 'add_providers' ], 11, 1 );
+		}
+	}
+
+	/**
+	 * Add the providers.
+	 *
+	 * @param array $providers The providers.
+	 * @return array
+	 */
+	public function add_providers( $providers ) {
+		$this->providers = [
+			new Page_Cache(),
+			new Browser_Cache(),
+			new Css_Minification(),
+			new Js_Minification(),
+			new Image_Lazy_Load(),
+			new Guest_Mode(),
+		];
+
+		return \array_merge(
+			$providers,
+			$this->providers
+		);
+	}
+}

--- a/classes/suggested-tasks/providers/integrations/litespeed-cache/class-browser-cache.php
+++ b/classes/suggested-tasks/providers/integrations/litespeed-cache/class-browser-cache.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Add task for LiteSpeed Cache: enable browser cache.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache;
+
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Task_Action_Builder;
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Ajax_Security_Litespeed_Cache;
+
+/**
+ * Add task for LiteSpeed Cache: enable browser cache.
+ */
+class Browser_Cache extends Litespeed_Cache_Interactive_Provider {
+
+	use Task_Action_Builder;
+	use Ajax_Security_Litespeed_Cache;
+
+	/**
+	 * The provider ID.
+	 *
+	 * @var string
+	 */
+	protected const PROVIDER_ID = 'litespeed-cache-browser-cache';
+
+	/**
+	 * The popover ID.
+	 *
+	 * @var string
+	 */
+	const POPOVER_ID = 'litespeed-cache-browser-cache';
+
+	/**
+	 * The external link URL.
+	 *
+	 * @var string
+	 */
+	protected const EXTERNAL_LINK_URL = 'https://prpl.fyi/litespeed-cache-browser-cache';
+
+	/**
+	 * Initialize the task.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		\add_action( 'wp_ajax_prpl_interactive_task_submit_litespeed-cache-browser-cache', [ $this, 'handle_interactive_task_specific_submit' ] );
+	}
+
+	/**
+	 * Get the task URL.
+	 *
+	 * @return string
+	 */
+	protected function get_url() {
+		return \admin_url( 'admin.php?page=litespeed-cache' );
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	protected function get_title() {
+		return \esc_html__( 'LiteSpeed Cache: enable browser cache', 'progress-planner' );
+	}
+
+	/**
+	 * Determine if the task should be added.
+	 *
+	 * @return bool
+	 */
+	public function should_add_task() {
+		if ( ! \defined( 'LSCWP_V' ) ) {
+			return false;
+		}
+
+		return ! (bool) $this->get_litespeed_option( 'cache-browser' );
+	}
+
+	/**
+	 * Get the popover instructions.
+	 *
+	 * @return void
+	 */
+	public function print_popover_instructions() {
+		echo '<p>';
+		\esc_html_e( 'Browser caching tells visitors\' browsers to store static files (images, CSS, JavaScript) locally. When they return to your site, these files load from their device instead of being downloaded again, making repeat visits significantly faster.', 'progress-planner' );
+		echo '</p>';
+	}
+
+	/**
+	 * Print the popover input field for the form.
+	 *
+	 * @return void
+	 */
+	public function print_popover_form_contents() {
+		$this->print_submit_button( \__( 'Enable browser cache', 'progress-planner' ) );
+	}
+
+	/**
+	 * Handle the interactive task submit.
+	 *
+	 * @return void
+	 */
+	public function handle_interactive_task_specific_submit() {
+		$this->verify_litespeed_cache_ajax_security();
+
+		$this->update_litespeed_option( 'cache-browser', 1 );
+
+		\wp_send_json_success( [ 'message' => \esc_html__( 'Setting updated.', 'progress-planner' ) ] );
+	}
+
+	/**
+	 * Add task actions specific to this task.
+	 *
+	 * @param array $data    The task data.
+	 * @param array $actions The existing actions.
+	 *
+	 * @return array
+	 */
+	public function add_task_actions( $data = [], $actions = [] ) {
+		return $this->add_popover_action( $actions, \__( 'Enable', 'progress-planner' ) );
+	}
+}

--- a/classes/suggested-tasks/providers/integrations/litespeed-cache/class-css-minification.php
+++ b/classes/suggested-tasks/providers/integrations/litespeed-cache/class-css-minification.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Add task for LiteSpeed Cache: enable CSS minification.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache;
+
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Task_Action_Builder;
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Ajax_Security_Litespeed_Cache;
+
+/**
+ * Add task for LiteSpeed Cache: enable CSS minification.
+ */
+class Css_Minification extends Litespeed_Cache_Interactive_Provider {
+
+	use Task_Action_Builder;
+	use Ajax_Security_Litespeed_Cache;
+
+	/**
+	 * The provider ID.
+	 *
+	 * @var string
+	 */
+	protected const PROVIDER_ID = 'litespeed-cache-css-minification';
+
+	/**
+	 * The popover ID.
+	 *
+	 * @var string
+	 */
+	const POPOVER_ID = 'litespeed-cache-css-minification';
+
+	/**
+	 * The external link URL.
+	 *
+	 * @var string
+	 */
+	protected const EXTERNAL_LINK_URL = 'https://prpl.fyi/litespeed-cache-css-minification';
+
+	/**
+	 * Initialize the task.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		\add_action( 'wp_ajax_prpl_interactive_task_submit_litespeed-cache-css-minification', [ $this, 'handle_interactive_task_specific_submit' ] );
+	}
+
+	/**
+	 * Get the task URL.
+	 *
+	 * @return string
+	 */
+	protected function get_url() {
+		return \admin_url( 'admin.php?page=litespeed-page_optm' );
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	protected function get_title() {
+		return \esc_html__( 'LiteSpeed Cache: enable CSS minification', 'progress-planner' );
+	}
+
+	/**
+	 * Determine if the task should be added.
+	 *
+	 * @return bool
+	 */
+	public function should_add_task() {
+		if ( ! \defined( 'LSCWP_V' ) ) {
+			return false;
+		}
+
+		return ! (bool) $this->get_litespeed_option( 'optm-css_min' );
+	}
+
+	/**
+	 * Get the popover instructions.
+	 *
+	 * @return void
+	 */
+	public function print_popover_instructions() {
+		echo '<p>';
+		\esc_html_e( 'CSS minification removes unnecessary whitespace, comments, and formatting from your CSS files, reducing their size by 10-30%. This is a low-risk optimization that helps pages load faster by reducing the amount of data browsers need to download.', 'progress-planner' );
+		echo '</p>';
+	}
+
+	/**
+	 * Print the popover input field for the form.
+	 *
+	 * @return void
+	 */
+	public function print_popover_form_contents() {
+		$this->print_submit_button( \__( 'Enable CSS minification', 'progress-planner' ) );
+	}
+
+	/**
+	 * Handle the interactive task submit.
+	 *
+	 * @return void
+	 */
+	public function handle_interactive_task_specific_submit() {
+		$this->verify_litespeed_cache_ajax_security();
+
+		$this->update_litespeed_option( 'optm-css_min', 1 );
+
+		\wp_send_json_success( [ 'message' => \esc_html__( 'Setting updated.', 'progress-planner' ) ] );
+	}
+
+	/**
+	 * Add task actions specific to this task.
+	 *
+	 * @param array $data    The task data.
+	 * @param array $actions The existing actions.
+	 *
+	 * @return array
+	 */
+	public function add_task_actions( $data = [], $actions = [] ) {
+		return $this->add_popover_action( $actions, \__( 'Enable', 'progress-planner' ) );
+	}
+}

--- a/classes/suggested-tasks/providers/integrations/litespeed-cache/class-guest-mode.php
+++ b/classes/suggested-tasks/providers/integrations/litespeed-cache/class-guest-mode.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Add task for LiteSpeed Cache: enable guest mode.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache;
+
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Task_Action_Builder;
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Ajax_Security_Litespeed_Cache;
+
+/**
+ * Add task for LiteSpeed Cache: enable guest mode.
+ */
+class Guest_Mode extends Litespeed_Cache_Interactive_Provider {
+
+	use Task_Action_Builder;
+	use Ajax_Security_Litespeed_Cache;
+
+	/**
+	 * The provider ID.
+	 *
+	 * @var string
+	 */
+	protected const PROVIDER_ID = 'litespeed-cache-guest-mode';
+
+	/**
+	 * The popover ID.
+	 *
+	 * @var string
+	 */
+	const POPOVER_ID = 'litespeed-cache-guest-mode';
+
+	/**
+	 * The external link URL.
+	 *
+	 * @var string
+	 */
+	protected const EXTERNAL_LINK_URL = 'https://prpl.fyi/litespeed-cache-guest-mode';
+
+	/**
+	 * Initialize the task.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		\add_action( 'wp_ajax_prpl_interactive_task_submit_litespeed-cache-guest-mode', [ $this, 'handle_interactive_task_specific_submit' ] );
+	}
+
+	/**
+	 * Get the task URL.
+	 *
+	 * @return string
+	 */
+	protected function get_url() {
+		return \admin_url( 'admin.php?page=litespeed-general' );
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	protected function get_title() {
+		return \esc_html__( 'LiteSpeed Cache: enable guest mode', 'progress-planner' );
+	}
+
+	/**
+	 * Determine if the task should be added.
+	 *
+	 * @return bool
+	 */
+	public function should_add_task() {
+		if ( ! \defined( 'LSCWP_V' ) ) {
+			return false;
+		}
+
+		return ! (bool) $this->get_litespeed_option( 'guest' );
+	}
+
+	/**
+	 * Get the popover instructions.
+	 *
+	 * @return void
+	 */
+	public function print_popover_instructions() {
+		echo '<p>';
+		\esc_html_e( 'Guest mode serves a cached version of your pages to first-time visitors before determining their specific cache vary. This improves the cache hit ratio and ensures most anonymous visitors get the fastest possible page loads.', 'progress-planner' );
+		echo '</p>';
+	}
+
+	/**
+	 * Print the popover input field for the form.
+	 *
+	 * @return void
+	 */
+	public function print_popover_form_contents() {
+		$this->print_submit_button( \__( 'Enable guest mode', 'progress-planner' ) );
+	}
+
+	/**
+	 * Handle the interactive task submit.
+	 *
+	 * @return void
+	 */
+	public function handle_interactive_task_specific_submit() {
+		$this->verify_litespeed_cache_ajax_security();
+
+		$this->update_litespeed_option( 'guest', 1 );
+
+		\wp_send_json_success( [ 'message' => \esc_html__( 'Setting updated.', 'progress-planner' ) ] );
+	}
+
+	/**
+	 * Add task actions specific to this task.
+	 *
+	 * @param array $data    The task data.
+	 * @param array $actions The existing actions.
+	 *
+	 * @return array
+	 */
+	public function add_task_actions( $data = [], $actions = [] ) {
+		return $this->add_popover_action( $actions, \__( 'Enable', 'progress-planner' ) );
+	}
+}

--- a/classes/suggested-tasks/providers/integrations/litespeed-cache/class-image-lazy-load.php
+++ b/classes/suggested-tasks/providers/integrations/litespeed-cache/class-image-lazy-load.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Add task for LiteSpeed Cache: enable image lazy loading.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache;
+
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Task_Action_Builder;
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Ajax_Security_Litespeed_Cache;
+
+/**
+ * Add task for LiteSpeed Cache: enable image lazy loading.
+ */
+class Image_Lazy_Load extends Litespeed_Cache_Interactive_Provider {
+
+	use Task_Action_Builder;
+	use Ajax_Security_Litespeed_Cache;
+
+	/**
+	 * The provider ID.
+	 *
+	 * @var string
+	 */
+	protected const PROVIDER_ID = 'litespeed-cache-image-lazy-load';
+
+	/**
+	 * The popover ID.
+	 *
+	 * @var string
+	 */
+	const POPOVER_ID = 'litespeed-cache-image-lazy-load';
+
+	/**
+	 * The external link URL.
+	 *
+	 * @var string
+	 */
+	protected const EXTERNAL_LINK_URL = 'https://prpl.fyi/litespeed-cache-image-lazy-load';
+
+	/**
+	 * Initialize the task.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		\add_action( 'wp_ajax_prpl_interactive_task_submit_litespeed-cache-image-lazy-load', [ $this, 'handle_interactive_task_specific_submit' ] );
+	}
+
+	/**
+	 * Get the task URL.
+	 *
+	 * @return string
+	 */
+	protected function get_url() {
+		return \admin_url( 'admin.php?page=litespeed-page_optm' );
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	protected function get_title() {
+		return \esc_html__( 'LiteSpeed Cache: enable image lazy loading', 'progress-planner' );
+	}
+
+	/**
+	 * Determine if the task should be added.
+	 *
+	 * @return bool
+	 */
+	public function should_add_task() {
+		if ( ! \defined( 'LSCWP_V' ) ) {
+			return false;
+		}
+
+		return ! (bool) $this->get_litespeed_option( 'media-lazy' );
+	}
+
+	/**
+	 * Get the popover instructions.
+	 *
+	 * @return void
+	 */
+	public function print_popover_instructions() {
+		echo '<p>';
+		\esc_html_e( 'Image lazy loading defers loading of images that are below the visible area of the page. Images are only loaded when the visitor scrolls near them. This significantly reduces initial page load time, especially on image-heavy pages.', 'progress-planner' );
+		echo '</p>';
+	}
+
+	/**
+	 * Print the popover input field for the form.
+	 *
+	 * @return void
+	 */
+	public function print_popover_form_contents() {
+		$this->print_submit_button( \__( 'Enable image lazy loading', 'progress-planner' ) );
+	}
+
+	/**
+	 * Handle the interactive task submit.
+	 *
+	 * @return void
+	 */
+	public function handle_interactive_task_specific_submit() {
+		$this->verify_litespeed_cache_ajax_security();
+
+		$this->update_litespeed_option( 'media-lazy', 1 );
+
+		\wp_send_json_success( [ 'message' => \esc_html__( 'Setting updated.', 'progress-planner' ) ] );
+	}
+
+	/**
+	 * Add task actions specific to this task.
+	 *
+	 * @param array $data    The task data.
+	 * @param array $actions The existing actions.
+	 *
+	 * @return array
+	 */
+	public function add_task_actions( $data = [], $actions = [] ) {
+		return $this->add_popover_action( $actions, \__( 'Enable', 'progress-planner' ) );
+	}
+}

--- a/classes/suggested-tasks/providers/integrations/litespeed-cache/class-js-minification.php
+++ b/classes/suggested-tasks/providers/integrations/litespeed-cache/class-js-minification.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Add task for LiteSpeed Cache: enable JS minification.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache;
+
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Task_Action_Builder;
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Ajax_Security_Litespeed_Cache;
+
+/**
+ * Add task for LiteSpeed Cache: enable JS minification.
+ */
+class Js_Minification extends Litespeed_Cache_Interactive_Provider {
+
+	use Task_Action_Builder;
+	use Ajax_Security_Litespeed_Cache;
+
+	/**
+	 * The provider ID.
+	 *
+	 * @var string
+	 */
+	protected const PROVIDER_ID = 'litespeed-cache-js-minification';
+
+	/**
+	 * The popover ID.
+	 *
+	 * @var string
+	 */
+	const POPOVER_ID = 'litespeed-cache-js-minification';
+
+	/**
+	 * The external link URL.
+	 *
+	 * @var string
+	 */
+	protected const EXTERNAL_LINK_URL = 'https://prpl.fyi/litespeed-cache-js-minification';
+
+	/**
+	 * Initialize the task.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		\add_action( 'wp_ajax_prpl_interactive_task_submit_litespeed-cache-js-minification', [ $this, 'handle_interactive_task_specific_submit' ] );
+	}
+
+	/**
+	 * Get the task URL.
+	 *
+	 * @return string
+	 */
+	protected function get_url() {
+		return \admin_url( 'admin.php?page=litespeed-page_optm' );
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	protected function get_title() {
+		return \esc_html__( 'LiteSpeed Cache: enable JS minification', 'progress-planner' );
+	}
+
+	/**
+	 * Determine if the task should be added.
+	 *
+	 * @return bool
+	 */
+	public function should_add_task() {
+		if ( ! \defined( 'LSCWP_V' ) ) {
+			return false;
+		}
+
+		return ! (bool) $this->get_litespeed_option( 'optm-js_min' );
+	}
+
+	/**
+	 * Get the popover instructions.
+	 *
+	 * @return void
+	 */
+	public function print_popover_instructions() {
+		echo '<p>';
+		\esc_html_e( 'JavaScript minification strips unnecessary characters from your JS files without changing their functionality. This reduces file sizes and helps your pages load faster, especially on slower connections.', 'progress-planner' );
+		echo '</p>';
+	}
+
+	/**
+	 * Print the popover input field for the form.
+	 *
+	 * @return void
+	 */
+	public function print_popover_form_contents() {
+		$this->print_submit_button( \__( 'Enable JS minification', 'progress-planner' ) );
+	}
+
+	/**
+	 * Handle the interactive task submit.
+	 *
+	 * @return void
+	 */
+	public function handle_interactive_task_specific_submit() {
+		$this->verify_litespeed_cache_ajax_security();
+
+		$this->update_litespeed_option( 'optm-js_min', 1 );
+
+		\wp_send_json_success( [ 'message' => \esc_html__( 'Setting updated.', 'progress-planner' ) ] );
+	}
+
+	/**
+	 * Add task actions specific to this task.
+	 *
+	 * @param array $data    The task data.
+	 * @param array $actions The existing actions.
+	 *
+	 * @return array
+	 */
+	public function add_task_actions( $data = [], $actions = [] ) {
+		return $this->add_popover_action( $actions, \__( 'Enable', 'progress-planner' ) );
+	}
+}

--- a/classes/suggested-tasks/providers/integrations/litespeed-cache/class-litespeed-cache-interactive-provider.php
+++ b/classes/suggested-tasks/providers/integrations/litespeed-cache/class-litespeed-cache-interactive-provider.php
@@ -45,12 +45,40 @@ abstract class Litespeed_Cache_Interactive_Provider extends Tasks_Interactive {
 	/**
 	 * Update a LiteSpeed Cache option value.
 	 *
+	 * Goes through LiteSpeed's own Conf::update_confs() rather than writing the
+	 * option row directly, because saving a setting is more than a database
+	 * write there: it casts the value to the option's declared type, purges the
+	 * caches the change invalidates, updates the relevant cron, and refreshes
+	 * LiteSpeed's in-memory config so the rest of the request sees the new
+	 * value.
+	 *
+	 * Guest mode is the clearest example -- Conf::update_confs() clears the
+	 * crawler's disabled list when `guest` changes, so writing the row on its
+	 * own leaves that list stale.
+	 *
+	 * Falls back to a direct write when LiteSpeed's class is unavailable, which
+	 * keeps this working if the plugin's internals move.
+	 *
 	 * @param string $option_key The LiteSpeed option key (e.g., 'cache', 'cache-browser').
 	 * @param mixed  $value      The value to set.
 	 *
 	 * @return bool Whether the option was updated.
 	 */
 	protected function update_litespeed_option( $option_key, $value ) {
+		$conf_class = '\LiteSpeed\Conf';
+
+		// @phpstan-ignore-next-line function.impossibleType -- LiteSpeed is not a dependency, so PHPStan cannot see the class; class_exists() guards it at runtime.
+		if ( \class_exists( $conf_class ) && \method_exists( $conf_class, 'cls' ) ) {
+			$conf = $conf_class::cls();
+
+			if ( \is_object( $conf ) && \method_exists( $conf, 'update_confs' ) ) {
+				$conf->update_confs( [ $option_key => $value ] );
+
+				// update_confs() returns nothing, so report on the stored value.
+				return (int) $this->get_litespeed_option( $option_key ) === (int) $value;
+			}
+		}
+
 		return \update_option( 'litespeed.conf.' . $option_key, $value );
 	}
 }

--- a/classes/suggested-tasks/providers/integrations/litespeed-cache/class-litespeed-cache-interactive-provider.php
+++ b/classes/suggested-tasks/providers/integrations/litespeed-cache/class-litespeed-cache-interactive-provider.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Abstract class for a LiteSpeed Cache interactive task provider.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache;
+
+use Progress_Planner\Suggested_Tasks\Providers\Tasks_Interactive;
+
+/**
+ * Add tasks for LiteSpeed Cache configuration.
+ */
+abstract class Litespeed_Cache_Interactive_Provider extends Tasks_Interactive {
+
+	/**
+	 * Whether the task is an onboarding task.
+	 *
+	 * @var bool
+	 */
+	protected const IS_ONBOARDING_TASK = false;
+
+	/**
+	 * The task priority.
+	 *
+	 * @var int
+	 */
+	protected $priority = 20;
+
+	/**
+	 * Get the LiteSpeed Cache option value.
+	 *
+	 * LiteSpeed Cache stores options as individual wp_options rows
+	 * with key format: litespeed.conf.{option_key}
+	 *
+	 * @param string $option_key The LiteSpeed option key (e.g., 'cache', 'cache-browser').
+	 *
+	 * @return mixed The option value, or false if not found.
+	 */
+	protected function get_litespeed_option( $option_key ) {
+		return \get_option( 'litespeed.conf.' . $option_key, false );
+	}
+
+	/**
+	 * Update a LiteSpeed Cache option value.
+	 *
+	 * @param string $option_key The LiteSpeed option key (e.g., 'cache', 'cache-browser').
+	 * @param mixed  $value      The value to set.
+	 *
+	 * @return bool Whether the option was updated.
+	 */
+	protected function update_litespeed_option( $option_key, $value ) {
+		return \update_option( 'litespeed.conf.' . $option_key, $value );
+	}
+}

--- a/classes/suggested-tasks/providers/integrations/litespeed-cache/class-page-cache.php
+++ b/classes/suggested-tasks/providers/integrations/litespeed-cache/class-page-cache.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Add task for LiteSpeed Cache: enable page cache.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache;
+
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Task_Action_Builder;
+use Progress_Planner\Suggested_Tasks\Providers\Traits\Ajax_Security_Litespeed_Cache;
+
+/**
+ * Add task for LiteSpeed Cache: enable page cache.
+ */
+class Page_Cache extends Litespeed_Cache_Interactive_Provider {
+
+	use Task_Action_Builder;
+	use Ajax_Security_Litespeed_Cache;
+
+	/**
+	 * The provider ID.
+	 *
+	 * @var string
+	 */
+	protected const PROVIDER_ID = 'litespeed-cache-page-cache';
+
+	/**
+	 * The popover ID.
+	 *
+	 * @var string
+	 */
+	const POPOVER_ID = 'litespeed-cache-page-cache';
+
+	/**
+	 * The external link URL.
+	 *
+	 * @var string
+	 */
+	protected const EXTERNAL_LINK_URL = 'https://prpl.fyi/litespeed-cache-page-cache';
+
+	/**
+	 * Initialize the task.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		\add_action( 'wp_ajax_prpl_interactive_task_submit_litespeed-cache-page-cache', [ $this, 'handle_interactive_task_specific_submit' ] );
+	}
+
+	/**
+	 * Get the task URL.
+	 *
+	 * @return string
+	 */
+	protected function get_url() {
+		return \admin_url( 'admin.php?page=litespeed-cache' );
+	}
+
+	/**
+	 * Get the title.
+	 *
+	 * @return string
+	 */
+	protected function get_title() {
+		return \esc_html__( 'LiteSpeed Cache: enable page cache', 'progress-planner' );
+	}
+
+	/**
+	 * Determine if the task should be added.
+	 *
+	 * @return bool
+	 */
+	public function should_add_task() {
+		if ( ! \defined( 'LSCWP_V' ) ) {
+			return false;
+		}
+
+		// Check if page cache is not enabled (value should be 1 for enabled).
+		return (int) $this->get_litespeed_option( 'cache' ) !== 1;
+	}
+
+	/**
+	 * Get the popover instructions.
+	 *
+	 * @return void
+	 */
+	public function print_popover_instructions() {
+		echo '<p>';
+		\esc_html_e( 'Page caching is the foundation of LiteSpeed Cache. It stores pre-built versions of your pages so they load instantly for visitors instead of being generated fresh each time. This is the single most impactful performance setting you can enable.', 'progress-planner' );
+		echo '</p>';
+	}
+
+	/**
+	 * Print the popover input field for the form.
+	 *
+	 * @return void
+	 */
+	public function print_popover_form_contents() {
+		$this->print_submit_button( \__( 'Enable page cache', 'progress-planner' ) );
+	}
+
+	/**
+	 * Handle the interactive task submit.
+	 *
+	 * @return void
+	 */
+	public function handle_interactive_task_specific_submit() {
+		$this->verify_litespeed_cache_ajax_security();
+
+		$this->update_litespeed_option( 'cache', 1 );
+
+		\wp_send_json_success( [ 'message' => \esc_html__( 'Setting updated.', 'progress-planner' ) ] );
+	}
+
+	/**
+	 * Add task actions specific to this task.
+	 *
+	 * @param array $data    The task data.
+	 * @param array $actions The existing actions.
+	 *
+	 * @return array
+	 */
+	public function add_task_actions( $data = [], $actions = [] ) {
+		return $this->add_popover_action( $actions, \__( 'Enable', 'progress-planner' ) );
+	}
+}

--- a/classes/suggested-tasks/providers/traits/class-ajax-security-litespeed-cache.php
+++ b/classes/suggested-tasks/providers/traits/class-ajax-security-litespeed-cache.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * LiteSpeed Cache-specific AJAX security checks.
+ *
+ * Extends the base Ajax_Security_Base trait with LiteSpeed Cache-specific
+ * validation methods.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Providers\Traits;
+
+/**
+ * Ajax_Security_Litespeed_Cache trait.
+ *
+ * This trait provides LiteSpeed Cache-specific security checks for AJAX handlers.
+ * It uses the base trait for common functionality.
+ */
+trait Ajax_Security_Litespeed_Cache {
+
+	use Ajax_Security_Base;
+
+	/**
+	 * Verify LiteSpeed Cache plugin is active or send JSON error and exit.
+	 *
+	 * Checks if the LSCWP_V constant is defined and terminates execution
+	 * with a JSON error response if not active.
+	 *
+	 * @return void Exits with wp_send_json_error() if LiteSpeed Cache is not active.
+	 */
+	protected function verify_litespeed_cache_active_or_fail() {
+		if ( ! \defined( 'LSCWP_V' ) ) {
+			\wp_send_json_error( [ 'message' => \esc_html__( 'LiteSpeed Cache is not active.', 'progress-planner' ) ] );
+		}
+	}
+
+	/**
+	 * Perform complete LiteSpeed Cache AJAX security checks.
+	 *
+	 * Runs LiteSpeed Cache active check, capability check, and nonce verification.
+	 * This is a convenience method for LiteSpeed Cache interactive tasks.
+	 *
+	 * @param string $capability The capability to require (default: 'manage_options').
+	 * @param string $action     The nonce action to verify (default: 'progress_planner').
+	 * @param string $field      The POST field containing the nonce (default: 'nonce').
+	 *
+	 * @return void Exits with wp_send_json_error() if any check fails.
+	 */
+	protected function verify_litespeed_cache_ajax_security( $capability = 'manage_options', $action = 'progress_planner', $field = 'nonce' ) {
+		$this->verify_litespeed_cache_active_or_fail();
+		$this->verify_ajax_security( $capability, $action, $field );
+	}
+}

--- a/tests/phpunit/stubs/class-litespeed-conf-stub.php
+++ b/tests/phpunit/stubs/class-litespeed-conf-stub.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Minimal stand-in for LiteSpeed's Conf class.
+ *
+ * LiteSpeed Cache is not installed in CI, so this records what
+ * update_litespeed_option() asks it to do and stores the value the way the real
+ * Conf does, letting the tests assert the update is routed through LiteSpeed
+ * rather than written straight to the option row.
+ *
+ * @package Progress_Planner\Tests
+ */
+
+// The stub has to occupy LiteSpeed's own namespace to stand in for its class.
+namespace LiteSpeed; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound
+
+if ( ! \class_exists( '\LiteSpeed\Conf' ) ) {
+
+	/**
+	 * Conf stub.
+	 */
+	class Conf {
+
+		/**
+		 * The calls made to update_confs().
+		 *
+		 * @var array[]
+		 */
+		private static $calls = [];
+
+		/**
+		 * Whether the stub should actually store values.
+		 *
+		 * @var bool
+		 */
+		private static $should_store = true;
+
+		/**
+		 * Get the singleton.
+		 *
+		 * @return self
+		 */
+		public static function cls() {
+			return new self();
+		}
+
+		/**
+		 * Record and apply a config update.
+		 *
+		 * @param array $the_matrix Option key => value pairs.
+		 *
+		 * @return void
+		 */
+		public function update_confs( $the_matrix = [] ) {
+			self::$calls[] = $the_matrix;
+
+			if ( ! self::$should_store ) {
+				return;
+			}
+
+			foreach ( $the_matrix as $key => $value ) {
+				\update_option( 'litespeed.conf.' . $key, $value );
+			}
+		}
+
+		/**
+		 * Get the recorded calls.
+		 *
+		 * @return array[]
+		 */
+		public static function get_calls() {
+			return self::$calls;
+		}
+
+		/**
+		 * Forget the recorded calls.
+		 *
+		 * @return void
+		 */
+		public static function reset_calls() {
+			self::$calls = [];
+		}
+
+		/**
+		 * Set whether the stub stores values.
+		 *
+		 * @param bool $should_store Whether to store.
+		 *
+		 * @return void
+		 */
+		public static function set_should_store( $should_store ) {
+			self::$should_store = (bool) $should_store;
+		}
+	}
+}

--- a/tests/phpunit/test-class-litespeed-cache.php
+++ b/tests/phpunit/test-class-litespeed-cache.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Tests for the LiteSpeed Cache task providers.
+ *
+ * The interesting behaviour is update_litespeed_option(): saving a LiteSpeed
+ * setting has to go through LiteSpeed's own Conf::update_confs(), which casts
+ * the value, purges the caches the change invalidates and refreshes LiteSpeed's
+ * in-memory config. Writing the option row directly skips all of that.
+ *
+ * LiteSpeed is not installed in CI, so a stub stands in for \LiteSpeed\Conf and
+ * records what it was asked to do.
+ *
+ * @package Progress_Planner\Tests
+ */
+
+namespace Progress_Planner\Tests;
+
+use Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache\Guest_Mode;
+use Progress_Planner\Suggested_Tasks\Providers\Integrations\Litespeed_Cache\Page_Cache;
+
+/**
+ * LiteSpeed Cache test case.
+ */
+class Litespeed_Cache_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Option keys the providers touch, so they can be restored.
+	 *
+	 * @var string[]
+	 */
+	private const OPTION_KEYS = [ 'cache', 'guest' ];
+
+	/**
+	 * Clean up.
+	 */
+	public function tear_down() {
+		foreach ( self::OPTION_KEYS as $key ) {
+			\delete_option( 'litespeed.conf.' . $key );
+		}
+
+		if ( \class_exists( '\LiteSpeed\Conf' ) ) {
+			\LiteSpeed\Conf::reset_calls();
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Call the provider's protected option updater.
+	 *
+	 * @param object $provider   The provider.
+	 * @param string $option_key The LiteSpeed option key.
+	 * @param mixed  $value      The value to set.
+	 *
+	 * @return mixed
+	 */
+	private function update_option_via( $provider, $option_key, $value ) {
+		$method = ( new \ReflectionClass( $provider ) )->getMethod( 'update_litespeed_option' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $provider, $option_key, $value );
+	}
+
+	/**
+	 * With LiteSpeed present, the update goes through its own Conf class.
+	 *
+	 * Writing the option row directly would leave LiteSpeed's caches unpurged
+	 * and its in-memory config stale -- for `guest` it also skips the crawler
+	 * disabled-list reset that Conf::update_confs() performs.
+	 *
+	 * @return void
+	 */
+	public function test_update_routes_through_litespeed_conf() {
+		require_once __DIR__ . '/stubs/class-litespeed-conf-stub.php';
+
+		$result = $this->update_option_via( new Guest_Mode(), 'guest', 1 );
+
+		$this->assertSame(
+			[ [ 'guest' => 1 ] ],
+			\LiteSpeed\Conf::get_calls(),
+			'The value should have been handed to Conf::update_confs().'
+		);
+		$this->assertTrue( $result, 'The update should report success.' );
+	}
+
+	/**
+	 * The provider reports failure when LiteSpeed did not store the value.
+	 *
+	 * Conf::update_confs() returns nothing, so success is read back from the
+	 * stored option rather than assumed.
+	 *
+	 * @return void
+	 */
+	public function test_update_reports_failure_when_value_is_not_stored() {
+		require_once __DIR__ . '/stubs/class-litespeed-conf-stub.php';
+
+		\LiteSpeed\Conf::set_should_store( false );
+
+		$result = $this->update_option_via( new Guest_Mode(), 'guest', 1 );
+
+		$this->assertFalse( $result, 'A value LiteSpeed refused to store is not a success.' );
+
+		\LiteSpeed\Conf::set_should_store( true );
+	}
+
+	/**
+	 * Each provider hands LiteSpeed its own option key.
+	 *
+	 * @return void
+	 */
+	public function test_each_provider_updates_its_own_option() {
+		require_once __DIR__ . '/stubs/class-litespeed-conf-stub.php';
+
+		$this->update_option_via( new Page_Cache(), 'cache', 1 );
+
+		$this->assertSame( [ [ 'cache' => 1 ] ], \LiteSpeed\Conf::get_calls() );
+	}
+
+	/**
+	 * The task is offered while the setting is off, and not once it is on.
+	 *
+	 * @return void
+	 */
+	public function test_should_add_task_follows_the_setting() {
+		if ( ! \defined( 'LSCWP_V' ) ) {
+			\define( 'LSCWP_V', '7.9' );
+		}
+
+		$provider = new Guest_Mode();
+
+		\update_option( 'litespeed.conf.guest', 0 );
+		$this->assertTrue( $provider->should_add_task(), 'A disabled setting should be suggested.' );
+
+		\update_option( 'litespeed.conf.guest', 1 );
+		$this->assertFalse( $provider->should_add_task(), 'An enabled setting should not be suggested.' );
+	}
+
+	/**
+	 * A string "1" counts as enabled.
+	 *
+	 * LiteSpeed casts values on save, so the stored option is not necessarily
+	 * the integer the provider wrote.
+	 *
+	 * @return void
+	 */
+	public function test_should_add_task_treats_string_one_as_enabled() {
+		if ( ! \defined( 'LSCWP_V' ) ) {
+			\define( 'LSCWP_V', '7.9' );
+		}
+
+		\update_option( 'litespeed.conf.guest', '1' );
+
+		$this->assertFalse(
+			( new Guest_Mode() )->should_add_task(),
+			'A string "1" is still enabled.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- Adds LiteSpeed Cache plugin integration following the existing AIOSEO pattern
- 6 interactive tasks that let users enable key performance settings directly from Progress Planner:
  - **Page cache** — foundation caching feature
  - **Browser cache** — client-side caching for repeat visitors
  - **CSS minification** — reduces CSS file sizes
  - **JS minification** — reduces JS file sizes
  - **Image lazy loading** — defers below-fold images
  - **Guest mode** — improves cache hit ratio for anonymous visitors
- Each task uses custom AJAX handlers with proper security (nonce + capability + plugin-active checks)
- Tasks only appear when LiteSpeed Cache is active and the corresponding setting is disabled

## Test plan
- [ ] Install and activate LiteSpeed Cache plugin
- [ ] Verify all 6 tasks appear in Progress Planner suggested tasks
- [ ] Click "Enable" on each task popover and verify the setting gets toggled on
- [ ] Verify task completes with confetti after enabling
- [ ] Deactivate LiteSpeed Cache and verify tasks disappear
- [ ] Verify tasks don't appear when settings are already enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)