### PR TITLE
Add Branding::enqueue_inline_css() so partner CSS can attach to any handle

### DIFF
--- a/classes/admin/class-page.php
+++ b/classes/admin/class-page.php
@@ -13,13 +13,6 @@ namespace Progress_Planner\Admin;
 class Page {
 
 	/**
-	 * Whether the branding inline styles have been added.
-	 *
-	 * @var boolean
-	 */
-	protected static $branding_inline_styles_added = false;
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -285,10 +278,7 @@ class Page {
 
 		\progress_planner()->get_admin__enqueue()->enqueue_style( 'progress-planner/variables-color' );
 		\progress_planner()->get_admin__enqueue()->enqueue_style( 'progress-planner/admin' );
-		if ( ! static::$branding_inline_styles_added ) {
-			\wp_add_inline_style( 'progress-planner/admin', \progress_planner()->get_ui__branding()->get_custom_css() );
-			static::$branding_inline_styles_added = true;
-		}
+		\progress_planner()->get_ui__branding()->enqueue_inline_css( 'progress-planner/admin' );
 		\progress_planner()->get_admin__enqueue()->enqueue_style( 'progress-planner/web-components/prpl-tooltip' );
 		\progress_planner()->get_admin__enqueue()->enqueue_style( 'progress-planner/web-components/prpl-install-plugin' );
 

--- a/classes/ui/class-branding.php
+++ b/classes/ui/class-branding.php
@@ -22,6 +22,13 @@ final class Branding {
 	];
 
 	/**
+	 * Style handles that have already received the branding inline CSS this request.
+	 *
+	 * @var array<string, bool>
+	 */
+	private static $inline_css_attached = [];
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -122,6 +129,30 @@ final class Branding {
 		return empty( $this->get_api_data() ) || empty( $this->get_api_data()['custom_css'] )
 			? ''
 			: $this->get_api_data()['custom_css'];
+	}
+
+	/**
+	 * Attach the branding custom CSS to a registered/enqueued stylesheet.
+	 *
+	 * Idempotent per handle within a single request, so callers do not need to
+	 * track whether the CSS has already been added.
+	 *
+	 * @param string $handle The style handle to attach the inline CSS to.
+	 *
+	 * @return void
+	 */
+	public function enqueue_inline_css( string $handle ): void {
+		if ( isset( self::$inline_css_attached[ $handle ] ) ) {
+			return;
+		}
+		self::$inline_css_attached[ $handle ] = true;
+
+		$css = $this->get_custom_css();
+		if ( '' === $css ) {
+			return;
+		}
+
+		\wp_add_inline_style( $handle, $css );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Adds `Branding::enqueue_inline_css( string $handle )` — attaches the partner branding `custom_css` to any registered/enqueued style handle, idempotent per handle per request.
- Refactors `Page::enqueue_styles()` to use it, removing the now-redundant `Page::$branding_inline_styles_added` static (the per-request dedupe still exists, just inside the new method).

## Why

Partner branding CSS is currently injected only on PP admin pages, because it's hardcoded into `Page::enqueue_styles()`. Other surfaces that should carry partner branding — the `pp-hosts` guided tour, which runs on the block editor, site editor, frontend, and non-PP admin screens — have no clean way to opt in.

This is a no-behavior-change refactor for PP itself: the same handle (`progress-planner/admin`) gets the same inline CSS as before, with the same once-per-request dedupe (which matters because dashboard widgets like `Dashboard_Widget_Score` and `Dashboard_Widget_Todo` call `enqueue_styles()` multiple times per request).

For external integrations, it makes the inline-CSS attachment a one-liner: `\progress_planner()->get_ui__branding()->enqueue_inline_css( 'my-handle' );`.

## Test plan

- [ ] Visit the Progress Planner admin page on a site with a branded `PROGRESS_PLANNER_BRANDING_ID` — partner custom CSS still applies (no visual change).
- [ ] Verify the inline CSS appears exactly once in the page source even when both score and todo dashboard widgets are rendered.
- [ ] On a site without branding (default ID), confirm no inline `<style>` is added (the early-return on empty `get_custom_css()` covers this).
- [ ] PHPStan + stylelint + eslint pass (verified locally via the pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)