### PR TITLE
Add critical security-update task with UI lockdown and admin alerts

### DIFF
--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -20,6 +20,7 @@ use Progress_Planner\Utils\Deprecations;
  * @method \Progress_Planner\Rest\Tasks get_rest__tasks()
  * @method \Progress_Planner\Todo get_todo()
  * @method \Progress_Planner\Utils\Onboard get_utils__onboard()
+ * @method \Progress_Planner\Utils\Security_Update_Monitor get_utils__security_update_monitor()
  * @method \Progress_Planner\Utils\Playground get_utils__playground()
  * @method \Progress_Planner\Admin\Page get_admin__page()
  * @method \Progress_Planner\Admin\Tour get_admin__tour()
@@ -119,6 +120,9 @@ class Base {
 		}
 
 		$this->get_suggested_tasks();
+
+		// Watches for core security releases; must run on front-end/cron requests too.
+		$this->get_utils__security_update_monitor();
 
 		$this->get_admin__editor();
 

--- a/classes/class-suggested-tasks-db.php
+++ b/classes/class-suggested-tasks-db.php
@@ -196,6 +196,9 @@ class Suggested_Tasks_DB {
 			\delete_option( $lock_key );
 		}
 
+		// Cached get() results are stale once a task is added.
+		\wp_cache_flush_group( static::GET_TASKS_CACHE_GROUP );
+
 		return $post_id;
 	}
 
@@ -236,6 +239,9 @@ class Suggested_Tasks_DB {
 				$update_results[] = (bool) \wp_set_object_terms( $id, $term->slug, $taxonomy ); // @phpstan-ignore-line property.nonObject
 			}
 		}
+
+		// Cached get() results are stale once a task changes (e.g. publish -> trash on completion).
+		\wp_cache_flush_group( static::GET_TASKS_CACHE_GROUP );
 
 		return ! \in_array( false, $update_results, true );
 	}

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -153,9 +153,11 @@ class Suggested_Tasks {
 	/**
 	 * If done via automatic updates, the "core update" task should be marked as "trashed" (and skip "pending" status).
 	 *
+	 * @param array $update_results The results of all attempted updates, keyed by type (core, plugin, theme, translation).
+	 *
 	 * @return void
 	 */
-	public function on_automatic_updates_complete(): void {
+	public function on_automatic_updates_complete( $update_results = [] ): void {
 		$providers = [
 			// The repetitive update-core task only counts within the current week.
 			'update-core'     => [ 'date_query' => [ [ 'after' => 'this Monday' ] ] ],
@@ -163,8 +165,15 @@ class Suggested_Tasks {
 			'security-update' => [],
 		];
 
+		// The hook also fires after plugin/theme-only runs; the security task is only
+		// completed when core itself was updated. Evaluation covers every other path.
+		if ( empty( $update_results['core'] ) ) {
+			unset( $providers['security-update'] );
+		}
+
 		foreach ( $providers as $provider_id => $extra_args ) {
-			$pending_tasks = \progress_planner()->get_suggested_tasks_db()->get(
+			// get_tasks_by() translates provider_id into the taxonomy query; get() would drop it.
+			$pending_tasks = \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
 				\array_merge(
 					[
 						'numberposts' => 1,

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -156,23 +156,34 @@ class Suggested_Tasks {
 	 * @return void
 	 */
 	public function on_automatic_updates_complete(): void {
-		$pending_tasks = \progress_planner()->get_suggested_tasks_db()->get(
-			[
-				'numberposts' => 1,
-				'post_status' => 'publish',
-				'provider_id' => 'update-core',
-				'date_query'  => [ [ 'after' => 'this Monday' ] ],
-			]
-		);
+		$providers = [
+			// The repetitive update-core task only counts within the current week.
+			'update-core'     => [ 'date_query' => [ [ 'after' => 'this Monday' ] ] ],
+			// The security-update task persists until the update is installed.
+			'security-update' => [],
+		];
 
-		if ( empty( $pending_tasks ) ) {
-			return;
+		foreach ( $providers as $provider_id => $extra_args ) {
+			$pending_tasks = \progress_planner()->get_suggested_tasks_db()->get(
+				\array_merge(
+					[
+						'numberposts' => 1,
+						'post_status' => 'publish',
+						'provider_id' => $provider_id,
+					],
+					$extra_args
+				)
+			);
+
+			if ( empty( $pending_tasks ) ) {
+				continue;
+			}
+
+			\progress_planner()->get_suggested_tasks_db()->update_recommendation( $pending_tasks[0]->ID, [ 'post_status' => 'trash' ] );
+
+			// Insert an activity.
+			$this->insert_activity( \progress_planner()->get_suggested_tasks()->get_task_id_from_slug( $pending_tasks[0]->post_name ) );
 		}
-
-		\progress_planner()->get_suggested_tasks_db()->update_recommendation( $pending_tasks[0]->ID, [ 'post_status' => 'trash' ] );
-
-		// Insert an activity.
-		$this->insert_activity( \progress_planner()->get_suggested_tasks()->get_task_id_from_slug( $pending_tasks[0]->post_name ) );
 	}
 
 	/**
@@ -484,6 +495,12 @@ class Suggested_Tasks {
 			$include_providers = \array_intersect( $include_providers, $request_providers );
 		}
 
+		// While a security-update task is pending, it is the only recommendation
+		// shown to users who can install it.
+		if ( $this->should_lock_down_recommendations( $request, $include_providers ) ) {
+			$include_providers = [ 'security-update' ];
+		}
+
 		$tax_query[] = [
 			'taxonomy' => 'prpl_recommendations_provider',
 			'field'    => 'slug',
@@ -506,6 +523,38 @@ class Suggested_Tasks {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Check whether a REST recommendations query must be locked down to the security-update task.
+	 *
+	 * The lockdown only applies to publish-status queries from users who can install
+	 * the update. The user's own to-do list (provider "user") and pending-celebration
+	 * queries are never locked down.
+	 *
+	 * @param \WP_REST_Request $request           The request object.
+	 * @param array            $include_providers The provider IDs available to the current user.
+	 *
+	 * @return bool
+	 */
+	private function should_lock_down_recommendations( $request, $include_providers ) {
+		// Only publish-status queries are locked down (celebrations & snoozed tasks flow normally).
+		$statuses = isset( $request['status'] ) ? (array) $request['status'] : [ 'publish' ];
+		if ( [ 'publish' ] !== \array_values( $statuses ) ) {
+			return false;
+		}
+
+		// The user's own to-do list is never locked down.
+		if ( isset( $request['provider'] ) && [ 'user' ] === \explode( ',', $request['provider'] ) ) {
+			return false;
+		}
+
+		// Only users who can install the update are locked down.
+		if ( ! \in_array( 'security-update', $include_providers, true ) ) {
+			return false;
+		}
+
+		return \progress_planner()->get_utils__security_update_monitor()->is_security_lockdown_active();
 	}
 
 	/**
@@ -553,7 +602,7 @@ class Suggested_Tasks {
 		if ( $provider ) {
 			$response->data['prpl_provider'] = $provider_term[0];
 			// Link should be added during run time, since it is not added for users without required capability.
-			$response->data['meta']['prpl_url'] = $response->data['meta']['prpl_url'] && $provider->capability_required()
+			$response->data['meta']['prpl_url'] = ! empty( $response->data['meta']['prpl_url'] ) && $provider->capability_required()
 				? \esc_url( (string) $response->data['meta']['prpl_url'] )
 				: '';
 
@@ -599,6 +648,27 @@ class Suggested_Tasks {
 				'posts_per_page'   => -1,
 			]
 		);
+
+		// While a security-update task is pending, it is the only recommendation
+		// served to users who can install it. User to-do lists and non-publish
+		// statuses (e.g. pending celebrations) are not affected.
+		if ( [ 'publish' ] === \array_values( (array) $args['post_status'] )
+			&& [ 'user' ] !== $args['include_provider']
+			&& \in_array(
+				'security-update',
+				\array_map(
+					static function ( $provider ) {
+						return $provider->get_provider_id();
+					},
+					$this->tasks_manager->get_task_providers_available_for_user()
+				),
+				true
+			)
+			&& \progress_planner()->get_utils__security_update_monitor()->is_security_lockdown_active()
+		) {
+			$args['include_provider'] = [ 'security-update' ];
+			$args['exclude_provider'] = [];
+		}
 
 		// Build query args for get_tasks_by.
 		$query_args = [

--- a/classes/suggested-tasks/class-tasks-manager.php
+++ b/classes/suggested-tasks/class-tasks-manager.php
@@ -22,6 +22,7 @@ use Progress_Planner\Suggested_Tasks\Providers\Rename_Uncategorized_Category;
 use Progress_Planner\Suggested_Tasks\Providers\Permalink_Structure;
 use Progress_Planner\Suggested_Tasks\Providers\Php_Version;
 use Progress_Planner\Suggested_Tasks\Providers\Search_Engine_Visibility;
+use Progress_Planner\Suggested_Tasks\Providers\Security_Update;
 use Progress_Planner\Suggested_Tasks\Tasks_Interface;
 use Progress_Planner\Suggested_Tasks\Providers\Integrations\Yoast\Add_Yoast_Providers;
 use Progress_Planner\Suggested_Tasks\Providers\Integrations\AIOSEO\Add_AIOSEO_Providers;
@@ -64,6 +65,7 @@ class Tasks_Manager {
 			new Content_Create(),
 			new Content_Review(),
 			new Core_Update(),
+			new Security_Update(),
 			new Blog_Description(),
 			new Debug_Display(),
 			new Disable_Comments(),

--- a/classes/suggested-tasks/providers/class-security-update.php
+++ b/classes/suggested-tasks/providers/class-security-update.php
@@ -236,12 +236,43 @@ class Security_Update extends Tasks {
 	/**
 	 * Add task actions specific to this task.
 	 *
+	 * The wp-admin Updates page only lists the latest release (get_core_updates()
+	 * skips "autoupdate" offers), so a branch-behind site would only be offered the
+	 * next major there. This form posts the exact branch version and locale to
+	 * core's own do-core-upgrade handler, which accepts any offer in the transient.
+	 *
 	 * @param array $data    The task data.
 	 * @param array $actions The existing actions.
 	 *
 	 * @return array
 	 */
 	public function add_task_actions( $data = [], $actions = [] ) {
+		$offer = Security_Update_Monitor::get_pending_security_update_offer();
+
+		if ( null !== $offer ) {
+			$form_action = \is_multisite()
+				? \network_admin_url( 'update-core.php?action=do-core-upgrade' )
+				: \admin_url( 'update-core.php?action=do-core-upgrade' );
+			$locale      = $offer->locale ?? 'en_US';
+
+			$actions[] = [
+				'priority' => 5,
+				'html'     => '<form method="post" action="' . \esc_url( $form_action ) . '" class="prpl-security-update-form">'
+					. \wp_nonce_field( 'upgrade-core', '_wpnonce', true, false )
+					. '<input type="hidden" name="upgrade" value="1">'
+					. '<input type="hidden" name="version" value="' . \esc_attr( $offer->current ) . '">'
+					. '<input type="hidden" name="locale" value="' . \esc_attr( $locale ) . '">'
+					. '<button type="submit" class="prpl-tooltip-action-text">'
+					. \sprintf(
+						/* translators: %s: The offered WordPress version. */
+						\esc_html__( 'Update to WordPress %s now', 'progress-planner' ),
+						\esc_html( $offer->current )
+					)
+					. '</button>'
+					. '</form>',
+			];
+		}
+
 		$actions[] = [
 			'priority' => 10,
 			'html'     => '<a class="prpl-tooltip-action-text" href="' . \admin_url( 'update-core.php' ) . '" target="_self">' . \esc_html__( 'Go to the Updates page', 'progress-planner' ) . '</a>',

--- a/classes/suggested-tasks/providers/class-security-update.php
+++ b/classes/suggested-tasks/providers/class-security-update.php
@@ -142,7 +142,7 @@ class Security_Update extends Tasks {
 
 		return '' === $version
 			? ! $this->should_add_task()
-			: \version_compare( Security_Update_Monitor::get_effective_installed_version(), $version, '>=' );
+			: \version_compare( Security_Update_Monitor::get_installed_version(), $version, '>=' );
 	}
 
 	/**
@@ -172,7 +172,7 @@ class Security_Update extends Tasks {
 		}
 
 		// Already installed: keep the task so evaluation can celebrate it.
-		if ( \version_compare( Security_Update_Monitor::get_effective_installed_version(), $version, '>=' ) ) {
+		if ( \version_compare( Security_Update_Monitor::get_installed_version(), $version, '>=' ) ) {
 			return true;
 		}
 
@@ -204,7 +204,7 @@ class Security_Update extends Tasks {
 
 			// Keep the task for the current offer, and completed-but-not-yet-celebrated tasks.
 			if ( $task_id === $current_task_id
-				|| ( '' !== $version && \version_compare( Security_Update_Monitor::get_effective_installed_version(), $version, '>=' ) )
+				|| ( '' !== $version && \version_compare( Security_Update_Monitor::get_installed_version(), $version, '>=' ) )
 			) {
 				continue;
 			}

--- a/classes/suggested-tasks/providers/class-security-update.php
+++ b/classes/suggested-tasks/providers/class-security-update.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Add a high-priority task for pending WordPress core security updates.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Suggested_Tasks\Providers;
+
+use Progress_Planner\Utils\Security_Update_Monitor;
+
+/**
+ * Add a task for a pending WordPress core security release.
+ *
+ * While this task is published it locks down the recommendations UI:
+ * it is the only task shown until the security update is installed.
+ */
+class Security_Update extends Tasks {
+
+	/**
+	 * The provider ID.
+	 *
+	 * @var string
+	 */
+	protected const PROVIDER_ID = 'security-update';
+
+	/**
+	 * The capability required to perform the task.
+	 *
+	 * @var string
+	 */
+	protected const CAPABILITY = 'update_core';
+
+	/**
+	 * Whether the task is repetitive.
+	 *
+	 * The task persists until the security update is installed.
+	 *
+	 * @var bool
+	 */
+	protected $is_repetitive = false;
+
+	/**
+	 * Whether the task is dismissable.
+	 *
+	 * @var bool
+	 */
+	protected $is_dismissable = false;
+
+	/**
+	 * Whether the task is snoozable.
+	 *
+	 * @var bool
+	 */
+	protected $is_snoozable = false;
+
+	/**
+	 * The task priority. 0 is the highest priority.
+	 *
+	 * @var int
+	 */
+	protected $priority = 0;
+
+	/**
+	 * The task points.
+	 *
+	 * @var int
+	 */
+	protected $points = 2;
+
+	/**
+	 * Get the task ID, versioned by the offered security release.
+	 *
+	 * Each security release gets its own task (e.g. security-update-6-8-2), so a
+	 * new release creates a fresh task even after an older one was completed.
+	 *
+	 * @param array $task_data Optional data to include in the task ID.
+	 *
+	 * @return string
+	 */
+	public function get_task_id( $task_data = [] ) {
+		$pending = Security_Update_Monitor::get_pending_security_update();
+
+		return null === $pending
+			? static::PROVIDER_ID
+			: static::PROVIDER_ID . '-' . \str_replace( '.', '-', $pending['offered'] );
+	}
+
+	/**
+	 * Get the task URL.
+	 *
+	 * @return string
+	 */
+	protected function get_url() {
+		return \admin_url( 'update-core.php' );
+	}
+
+	/**
+	 * Get the task title.
+	 *
+	 * @return string
+	 */
+	protected function get_title() {
+		$pending = Security_Update_Monitor::get_pending_security_update();
+
+		return null === $pending
+			? \esc_html__( 'Install the WordPress security update', 'progress-planner' )
+			: \sprintf(
+				/* translators: %s: The offered WordPress version. */
+				\esc_html__( 'Install the WordPress %s security update', 'progress-planner' ),
+				$pending['offered']
+			);
+	}
+
+	/**
+	 * Get the task description.
+	 *
+	 * @return string
+	 */
+	protected function get_description() {
+		return \esc_html__( 'A WordPress security release is available. Security issues are typically exploited within hours of a release, so install this update as soon as possible.', 'progress-planner' );
+	}
+
+	/**
+	 * Check if the task should be added.
+	 *
+	 * @return bool
+	 */
+	public function should_add_task() {
+		return null !== Security_Update_Monitor::get_pending_security_update();
+	}
+
+	/**
+	 * Check if a specific task is completed.
+	 *
+	 * @param string $task_id The task ID to check.
+	 *
+	 * @return bool
+	 */
+	protected function is_specific_task_completed( $task_id ) {
+		$version = $this->get_version_from_task_id( $task_id );
+
+		return '' === $version
+			? ! $this->should_add_task()
+			: \version_compare( Security_Update_Monitor::get_effective_installed_version(), $version, '>=' );
+	}
+
+	/**
+	 * Check if the published task is still relevant.
+	 *
+	 * A task stays relevant while its version is still offered, or once it has been
+	 * installed (so evaluation can celebrate it). A withdrawn offer makes the task
+	 * irrelevant and it is deleted without celebration.
+	 *
+	 * @return bool
+	 */
+	public function is_task_relevant() {
+		$tasks = (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'post_status' => 'publish',
+				'provider_id' => static::PROVIDER_ID,
+			]
+		);
+
+		if ( empty( $tasks ) ) {
+			return true;
+		}
+
+		$version = $this->get_version_from_task_id( (string) $tasks[0]->post_name );
+		if ( '' === $version ) {
+			return false;
+		}
+
+		// Already installed: keep the task so evaluation can celebrate it.
+		if ( \version_compare( Security_Update_Monitor::get_effective_installed_version(), $version, '>=' ) ) {
+			return true;
+		}
+
+		// Otherwise the task is only relevant while its version is still offered.
+		$pending = Security_Update_Monitor::get_pending_security_update();
+
+		return null !== $pending && $pending['offered'] === $version;
+	}
+
+	/**
+	 * Get an array of tasks to inject.
+	 *
+	 * Removes published tasks for superseded or withdrawn releases before
+	 * injecting the task for the currently offered release.
+	 *
+	 * @return array
+	 */
+	public function get_tasks_to_inject() {
+		$current_task_id = $this->should_add_task() ? $this->get_task_id() : '';
+
+		foreach ( (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'post_status' => 'publish',
+				'provider_id' => static::PROVIDER_ID,
+			]
+		) as $task ) {
+			$task_id = \progress_planner()->get_suggested_tasks()->get_task_id_from_slug( (string) $task->post_name );
+			$version = $this->get_version_from_task_id( $task_id );
+
+			// Keep the task for the current offer, and completed-but-not-yet-celebrated tasks.
+			if ( $task_id === $current_task_id
+				|| ( '' !== $version && \version_compare( Security_Update_Monitor::get_effective_installed_version(), $version, '>=' ) )
+			) {
+				continue;
+			}
+
+			\progress_planner()->get_suggested_tasks_db()->delete_recommendation( $task->ID );
+		}
+
+		return parent::get_tasks_to_inject();
+	}
+
+	/**
+	 * Add the offered and installed versions to the injected task data.
+	 *
+	 * @param array $task_data The task data.
+	 *
+	 * @return array
+	 */
+	protected function modify_injection_task_data( $task_data ) {
+		$pending = Security_Update_Monitor::get_pending_security_update();
+
+		if ( null !== $pending ) {
+			$task_data['offered_version']   = $pending['offered'];
+			$task_data['installed_version'] = $pending['installed'];
+		}
+
+		return $task_data;
+	}
+
+	/**
+	 * Add task actions specific to this task.
+	 *
+	 * @param array $data    The task data.
+	 * @param array $actions The existing actions.
+	 *
+	 * @return array
+	 */
+	public function add_task_actions( $data = [], $actions = [] ) {
+		$actions[] = [
+			'priority' => 10,
+			'html'     => '<a class="prpl-tooltip-action-text" href="' . \admin_url( 'update-core.php' ) . '" target="_self">' . \esc_html__( 'Go to the Updates page', 'progress-planner' ) . '</a>',
+		];
+
+		return $actions;
+	}
+
+	/**
+	 * Extract the version from a versioned task ID.
+	 *
+	 * @param string $task_id The task ID (e.g. security-update-6-8-2).
+	 *
+	 * @return string The version (e.g. 6.8.2), or an empty string.
+	 */
+	private function get_version_from_task_id( $task_id ) {
+		if ( ! \preg_match( '/^' . static::PROVIDER_ID . '-(\d+(?:-\d+)*)$/', $task_id, $matches ) ) {
+			return '';
+		}
+
+		return \str_replace( '-', '.', $matches[1] );
+	}
+}

--- a/classes/suggested-tasks/providers/class-security-update.php
+++ b/classes/suggested-tasks/providers/class-security-update.php
@@ -118,7 +118,7 @@ class Security_Update extends Tasks {
 	 * @return string
 	 */
 	protected function get_description() {
-		return \esc_html__( 'A WordPress security release is available. Security issues are typically exploited within hours of a release, so install this update as soon as possible.', 'progress-planner' );
+		return \esc_html__( 'A WordPress security release is available. Security issues are typically exploited within hours of a release, so install this update as soon as possible. If you have a backup solution, make a fresh backup first — but do not postpone the update if you have none.', 'progress-planner' );
 	}
 
 	/**

--- a/classes/utils/class-security-update-monitor.php
+++ b/classes/utils/class-security-update-monitor.php
@@ -82,9 +82,10 @@ class Security_Update_Monitor {
 
 		try {
 			$this->send_admin_email( $update['installed'], $update['offered'] );
-			$this->send_saas_ping( $update['installed'], $update['offered'] );
 
 			// Mark as alerted even if sending failed, to avoid alert storms on every request.
+			// The subscriber email is sent by progressplanner.com, which watches the
+			// wordpress.org releases feed and reads this site's version via get-stats.
 			\update_site_option( self::ALERTED_VERSION_OPTION, $update['offered'] );
 		} finally {
 			\delete_option( self::LOCK_OPTION );
@@ -157,38 +158,6 @@ This alert was sent by the Progress Planner plugin.',
 		}
 
 		return \array_values( \array_unique( $emails ) );
-	}
-
-	/**
-	 * Notify the Progress Planner SaaS so it can email the registered subscriber.
-	 *
-	 * @param string $installed The installed version.
-	 * @param string $offered   The offered version.
-	 *
-	 * @return void
-	 */
-	private function send_saas_ping( $installed, $offered ) {
-		$license_key = \get_option( 'progress_planner_license_key' );
-		if ( ! $license_key || 'no-license' === $license_key ) {
-			return;
-		}
-
-		$onboard = \progress_planner()->get_utils__onboard();
-
-		// Fire-and-forget: the SaaS emails the registered subscriber.
-		\wp_remote_post(
-			$onboard->get_remote_url( 'security-update-alert' ),
-			[
-				'timeout' => 10,
-				'body'    => [
-					'license_key'       => $license_key,
-					'site'              => \set_url_scheme( \site_url() ),
-					'installed_version' => $installed,
-					'offered_version'   => $offered,
-					'nonce'             => $onboard->get_remote_nonce(),
-				],
-			]
-		);
 	}
 
 	/**

--- a/classes/utils/class-security-update-monitor.php
+++ b/classes/utils/class-security-update-monitor.php
@@ -108,27 +108,47 @@ class Security_Update_Monitor {
 			$offered
 		);
 
-		$message = \sprintf(
-			/* translators: 1: The offered WordPress version, 2: The installed WordPress version, 3: The URL of the updates page, 4: The URL of the WordPress backups documentation. */
-			\__(
-				'A WordPress security release is available: version %1$s (your site runs %2$s).
+		// Onboarded sites go to the Progress Planner dashboard, which carries the
+		// one-click branch-pinned update button. The wp-admin Updates page only
+		// offers the latest major, so it is just the fallback for sites that have
+		// not onboarded yet (their dashboard would show the welcome screen).
+		$is_onboarded = \progress_planner()->is_privacy_policy_accepted();
+		$action_url   = $is_onboarded
+			? \admin_url( 'admin.php?page=progress-planner' )
+			: \admin_url( 'update-core.php' );
 
-Security issues in WordPress are typically exploited within hours of a release, so please update as soon as possible:
-
-%3$s
-
-If you have a backup solution, make a fresh backup before updating — but do not postpone the update if you have none. Learn more about backups: %4$s
-
-If your site has automatic updates enabled, it may install this update by itself — in that case, please verify on the page above that the update has been applied.
-
-This alert was sent by the Progress Planner plugin.',
-				'progress-planner'
+		$paragraphs = [
+			\sprintf(
+				/* translators: 1: The offered WordPress version, 2: The installed WordPress version. */
+				\__( 'A WordPress security release is available: version %1$s (your site runs %2$s).', 'progress-planner' ),
+				$offered,
+				$installed
 			),
-			$offered,
-			$installed,
-			\admin_url( 'update-core.php' ),
+			\sprintf(
+				/* translators: %s: The URL where the update can be installed. */
+				\__(
+					'Security issues in WordPress are typically exploited within hours of a release, so please update as soon as possible:
+
+%s',
+					'progress-planner'
+				),
+				$action_url
+			),
+		];
+
+		if ( $is_onboarded ) {
+			$paragraphs[] = \__( 'Your Progress Planner dashboard has a one-click button to install exactly this update; the task will be marked complete once your site is updated.', 'progress-planner' );
+		}
+
+		$paragraphs[] = \sprintf(
+			/* translators: %s: The URL of the WordPress backups documentation. */
+			\__( 'If you have a backup solution, make a fresh backup before updating — but do not postpone the update if you have none. Learn more about backups: %s', 'progress-planner' ),
 			'https://wordpress.org/documentation/article/wordpress-backups/'
 		);
+		$paragraphs[] = \__( 'If your site has automatic updates enabled, it may install this update by itself — in that case, please verify that the update has been applied.', 'progress-planner' );
+		$paragraphs[] = \__( 'This alert was sent by the Progress Planner plugin.', 'progress-planner' );
+
+		$message = \implode( "\n\n", $paragraphs );
 
 		foreach ( $this->get_recipients() as $email ) {
 			\wp_mail( $email, $subject, $message );

--- a/classes/utils/class-security-update-monitor.php
+++ b/classes/utils/class-security-update-monitor.php
@@ -217,6 +217,32 @@ This alert was sent by the Progress Planner plugin.',
 	 * @return array{installed: string, offered: string}|null
 	 */
 	public static function get_pending_security_update( $transient = null, $installed = null ) {
+		if ( null === $installed ) {
+			$installed = self::get_installed_version();
+		}
+
+		$offer = self::get_pending_security_update_offer( $transient, $installed );
+
+		return null === $offer
+			? null
+			: [
+				'installed' => $installed,
+				'offered'   => $offer->current,
+			];
+	}
+
+	/**
+	 * Get the update offer object for the pending security update, if any.
+	 *
+	 * The offer carries the exact version and locale needed to run a
+	 * version-pinned core upgrade through wp-admin/update-core.php.
+	 *
+	 * @param object|null $transient The update_core site transient. Defaults to the stored transient.
+	 * @param string|null $installed The installed version. Defaults to the running WordPress version.
+	 *
+	 * @return object{response: string, current: string, locale?: string}|null
+	 */
+	public static function get_pending_security_update_offer( $transient = null, $installed = null ) {
 		if ( null === $transient ) {
 			$transient = \get_site_transient( 'update_core' );
 		}
@@ -229,7 +255,12 @@ This alert was sent by the Progress Planner plugin.',
 			return null;
 		}
 
-		$offered = null;
+		/**
+		 * The best matching offer.
+		 *
+		 * @var object{response: string, current: string, locale?: string}|null $offer
+		 */
+		$offer = null;
 		foreach ( $transient->updates as $update ) {
 			// Same-branch point releases are offered with response "autoupdate" (only the
 			// newest release gets "upgrade"), so a branch-behind site (e.g. 6.9.1 when
@@ -243,17 +274,12 @@ This alert was sent by the Progress Planner plugin.',
 				continue;
 			}
 
-			if ( null === $offered || \version_compare( $update->current, $offered, '>' ) ) {
-				$offered = $update->current;
+			if ( null === $offer || \version_compare( $update->current, $offer->current, '>' ) ) {
+				$offer = $update;
 			}
 		}
 
-		return null === $offered
-			? null
-			: [
-				'installed' => $installed,
-				'offered'   => $offered,
-			];
+		return $offer;
 	}
 
 	/**

--- a/classes/utils/class-security-update-monitor.php
+++ b/classes/utils/class-security-update-monitor.php
@@ -109,13 +109,15 @@ class Security_Update_Monitor {
 		);
 
 		$message = \sprintf(
-			/* translators: 1: The offered WordPress version, 2: The installed WordPress version, 3: The URL of the updates page. */
+			/* translators: 1: The offered WordPress version, 2: The installed WordPress version, 3: The URL of the updates page, 4: The URL of the WordPress backups documentation. */
 			\__(
 				'A WordPress security release is available: version %1$s (your site runs %2$s).
 
 Security issues in WordPress are typically exploited within hours of a release, so please update as soon as possible:
 
 %3$s
+
+If you have a backup solution, make a fresh backup before updating — but do not postpone the update if you have none. Learn more about backups: %4$s
 
 If your site has automatic updates enabled, it may install this update by itself — in that case, please verify on the page above that the update has been applied.
 
@@ -124,7 +126,8 @@ This alert was sent by the Progress Planner plugin.',
 			),
 			$offered,
 			$installed,
-			\admin_url( 'update-core.php' )
+			\admin_url( 'update-core.php' ),
+			'https://wordpress.org/documentation/article/wordpress-backups/'
 		);
 
 		foreach ( $this->get_recipients() as $email ) {

--- a/classes/utils/class-security-update-monitor.php
+++ b/classes/utils/class-security-update-monitor.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * Monitor WordPress core for pending security updates.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Utils;
+
+/**
+ * Detects pending WordPress core security releases.
+ *
+ * Every core patch release (same major.minor, higher patch) is treated
+ * as a security release.
+ */
+class Security_Update_Monitor {
+
+	/**
+	 * The option holding the last offered version we alerted about.
+	 *
+	 * @var string
+	 */
+	const ALERTED_VERSION_OPTION = 'progress_planner_security_update_alerted_version';
+
+	/**
+	 * The option used as a short-lived lock while sending alerts.
+	 *
+	 * @var string
+	 */
+	const LOCK_OPTION = 'prpl_security_alert_lock';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		// Fires whenever wp_version_check() refreshes the transient, including on front-end cron.
+		\add_action( 'set_site_transient_update_core', [ $this, 'maybe_alert' ] );
+
+		// Fallback re-check, before Suggested_Tasks::init() runs on admin_init:20.
+		\add_action( 'admin_init', [ $this, 'maybe_alert_from_stored_transient' ], 5 );
+	}
+
+	/**
+	 * Re-check the stored transient (fallback for sites where the hook never fired).
+	 *
+	 * @return void
+	 */
+	public function maybe_alert_from_stored_transient() {
+		$this->maybe_alert( \get_site_transient( 'update_core' ) );
+	}
+
+	/**
+	 * Alert site admins (and the SaaS) about a pending security update, once per offered version.
+	 *
+	 * @param mixed $transient The update_core site transient value.
+	 *
+	 * @return void
+	 */
+	public function maybe_alert( $transient ) {
+		if ( \is_multisite() && ! \is_main_site() ) {
+			return;
+		}
+
+		$update = self::get_pending_security_update( \is_object( $transient ) ? $transient : null );
+		if ( null === $update ) {
+			return;
+		}
+
+		// One alert per offered version.
+		if ( \get_site_option( self::ALERTED_VERSION_OPTION ) === $update['offered'] ) {
+			return;
+		}
+
+		// Cron and a concurrent admin pageview can both fire this; take a short-lived lock.
+		if ( ! \add_option( self::LOCK_OPTION, \time(), '', false ) ) {
+			$lock_time = (int) \get_option( self::LOCK_OPTION );
+			if ( $lock_time > \time() - 30 ) {
+				return;
+			}
+			\update_option( self::LOCK_OPTION, \time(), false );
+		}
+
+		try {
+			$this->send_admin_email( $update['installed'], $update['offered'] );
+			$this->send_saas_ping( $update['installed'], $update['offered'] );
+
+			// Mark as alerted even if sending failed, to avoid alert storms on every request.
+			\update_site_option( self::ALERTED_VERSION_OPTION, $update['offered'] );
+		} finally {
+			\delete_option( self::LOCK_OPTION );
+		}
+	}
+
+	/**
+	 * Email every user who can install core updates about the security release.
+	 *
+	 * @param string $installed The installed version.
+	 * @param string $offered   The offered version.
+	 *
+	 * @return void
+	 */
+	private function send_admin_email( $installed, $offered ) {
+		$subject = \sprintf(
+			/* translators: 1: The site name, 2: The offered WordPress version. */
+			\__( '[%1$s] Critical: WordPress %2$s security update available', 'progress-planner' ),
+			\wp_specialchars_decode( (string) \get_option( 'blogname' ), ENT_QUOTES ),
+			$offered
+		);
+
+		$message = \sprintf(
+			/* translators: 1: The offered WordPress version, 2: The installed WordPress version, 3: The URL of the updates page. */
+			\__(
+				'A WordPress security release is available: version %1$s (your site runs %2$s).
+
+Security issues in WordPress are typically exploited within hours of a release, so please update as soon as possible:
+
+%3$s
+
+If your site has automatic updates enabled, it may install this update by itself — in that case, please verify on the page above that the update has been applied.
+
+This alert was sent by the Progress Planner plugin.',
+				'progress-planner'
+			),
+			$offered,
+			$installed,
+			\admin_url( 'update-core.php' )
+		);
+
+		foreach ( $this->get_recipients() as $email ) {
+			\wp_mail( $email, $subject, $message );
+		}
+	}
+
+	/**
+	 * Get the email addresses of all users who can install core updates.
+	 *
+	 * @return string[]
+	 */
+	private function get_recipients() {
+		if ( \is_multisite() ) {
+			$emails = [];
+			foreach ( \get_super_admins() as $login ) {
+				$user = \get_user_by( 'login', $login );
+				if ( $user ) {
+					$emails[] = $user->user_email;
+				}
+			}
+
+			return \array_values( \array_unique( $emails ) );
+		}
+
+		$emails = [];
+		foreach ( \get_users( [ 'capability' => 'update_core' ] ) as $user ) {
+			if ( $user instanceof \WP_User ) {
+				$emails[] = $user->user_email;
+			}
+		}
+
+		return \array_values( \array_unique( $emails ) );
+	}
+
+	/**
+	 * Notify the Progress Planner SaaS so it can email the registered subscriber.
+	 *
+	 * @param string $installed The installed version.
+	 * @param string $offered   The offered version.
+	 *
+	 * @return void
+	 */
+	private function send_saas_ping( $installed, $offered ) {
+		$license_key = \get_option( 'progress_planner_license_key' );
+		if ( ! $license_key || 'no-license' === $license_key ) {
+			return;
+		}
+
+		$onboard = \progress_planner()->get_utils__onboard();
+
+		// Fire-and-forget: the SaaS emails the registered subscriber.
+		\wp_remote_post(
+			$onboard->get_remote_url( 'security-update-alert' ),
+			[
+				'timeout' => 10,
+				'body'    => [
+					'license_key'       => $license_key,
+					'site'              => \set_url_scheme( \site_url() ),
+					'installed_version' => $installed,
+					'offered_version'   => $offered,
+					'nonce'             => $onboard->get_remote_nonce(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Check whether a security-update task is currently published.
+	 *
+	 * While one is published, the recommendations UI is locked down to that task.
+	 *
+	 * @return bool
+	 */
+	public function is_security_lockdown_active() {
+		return ! empty(
+			\progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+				[
+					'post_status' => 'publish',
+					'provider_id' => 'security-update',
+					'numberposts' => 1,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Check whether an offered version is a security release, compared to the installed one.
+	 *
+	 * A security release is a patch release on the same branch: same major.minor,
+	 * with a higher patch number. Non-stable versions (alpha/beta/RC) never qualify.
+	 *
+	 * @param string $installed The installed WordPress version.
+	 * @param string $offered   The offered WordPress version.
+	 *
+	 * @return bool
+	 */
+	public static function is_security_release( $installed, $offered ) {
+		// Non-stable versions (e.g. 6.9-alpha-59000, 6.9-RC1) never qualify.
+		if ( false !== \strpos( $installed, '-' ) || false !== \strpos( $offered, '-' ) ) {
+			return false;
+		}
+
+		$installed_parts = self::get_version_parts( $installed );
+		$offered_parts   = self::get_version_parts( $offered );
+
+		if ( null === $installed_parts || null === $offered_parts ) {
+			return false;
+		}
+
+		return $installed_parts[0] === $offered_parts[0]
+			&& $installed_parts[1] === $offered_parts[1]
+			&& $offered_parts[2] > $installed_parts[2];
+	}
+
+	/**
+	 * Get the pending security update from an update_core transient, if any.
+	 *
+	 * @param object|null $transient The update_core site transient. Defaults to the stored transient.
+	 * @param string|null $installed The installed version. Defaults to the running WordPress version.
+	 *
+	 * @return array{installed: string, offered: string}|null
+	 */
+	public static function get_pending_security_update( $transient = null, $installed = null ) {
+		if ( null === $transient ) {
+			$transient = \get_site_transient( 'update_core' );
+		}
+
+		if ( null === $installed ) {
+			$installed = self::get_installed_version();
+		}
+
+		if ( ! \is_object( $transient ) || ! isset( $transient->updates ) || ! \is_array( $transient->updates ) ) {
+			return null;
+		}
+
+		$offered = null;
+		foreach ( $transient->updates as $update ) {
+			if ( ! \is_object( $update )
+				|| ! isset( $update->response, $update->current )
+				|| 'upgrade' !== $update->response
+				|| ! \is_string( $update->current )
+				|| ! self::is_security_release( $installed, $update->current )
+			) {
+				continue;
+			}
+
+			if ( null === $offered || \version_compare( $update->current, $offered, '>' ) ) {
+				$offered = $update->current;
+			}
+		}
+
+		return null === $offered
+			? null
+			: [
+				'installed' => $installed,
+				'offered'   => $offered,
+			];
+	}
+
+	/**
+	 * Get the effective installed WordPress version.
+	 *
+	 * Returns the higher of the running version and the version recorded by the
+	 * last update check (the transient's version_checked), so a just-installed
+	 * update is recognized as soon as the update check has run.
+	 *
+	 * @return string
+	 */
+	public static function get_effective_installed_version() {
+		$installed = self::get_installed_version();
+		$transient = \get_site_transient( 'update_core' );
+
+		if ( \is_object( $transient )
+			&& isset( $transient->version_checked )
+			&& \is_string( $transient->version_checked )
+			&& \version_compare( $transient->version_checked, $installed, '>' )
+		) {
+			return $transient->version_checked;
+		}
+
+		return $installed;
+	}
+
+	/**
+	 * Get the installed WordPress version.
+	 *
+	 * @return string
+	 */
+	private static function get_installed_version() {
+		// wp_get_wp_version() exists since WP 6.7; the plugin supports 6.6.
+		if ( \function_exists( 'wp_get_wp_version' ) ) {
+			return \wp_get_wp_version();
+		}
+
+		return isset( $GLOBALS['wp_version'] ) && \is_string( $GLOBALS['wp_version'] ) ? $GLOBALS['wp_version'] : '';
+	}
+
+	/**
+	 * Split a version string into major, minor and patch integers.
+	 *
+	 * @param string $version The version string.
+	 *
+	 * @return array{int, int, int}|null Null when the version is not parsable.
+	 */
+	private static function get_version_parts( $version ) {
+		if ( ! \preg_match( '/^(\d+)\.(\d+)(?:\.(\d+))?$/', $version, $matches ) ) {
+			return null;
+		}
+
+		return [ (int) $matches[1], (int) $matches[2], isset( $matches[3] ) ? (int) $matches[3] : 0 ];
+	}
+}

--- a/classes/utils/class-security-update-monitor.php
+++ b/classes/utils/class-security-update-monitor.php
@@ -72,12 +72,17 @@ class Security_Update_Monitor {
 		}
 
 		// Cron and a concurrent admin pageview can both fire this; take a short-lived lock.
-		if ( ! \add_option( self::LOCK_OPTION, \time(), '', false ) ) {
-			$lock_time = (int) \get_option( self::LOCK_OPTION );
+		// Network options, like the alerted-version option, so single- and multisite behave alike.
+		if ( ! \add_site_option( self::LOCK_OPTION, \time() ) ) {
+			$lock_time = (int) \get_site_option( self::LOCK_OPTION );
 			if ( $lock_time > \time() - 30 ) {
 				return;
 			}
-			\update_option( self::LOCK_OPTION, \time(), false );
+
+			// Stale lock (crashed process): clear it and bail. Proceeding here would let two
+			// concurrent requests both send; the next trigger takes a fresh lock atomically.
+			\delete_site_option( self::LOCK_OPTION );
+			return;
 		}
 
 		try {
@@ -88,7 +93,7 @@ class Security_Update_Monitor {
 			// wordpress.org releases feed and reads this site's version via get-stats.
 			\update_site_option( self::ALERTED_VERSION_OPTION, $update['offered'] );
 		} finally {
-			\delete_option( self::LOCK_OPTION );
+			\delete_site_option( self::LOCK_OPTION );
 		}
 	}
 
@@ -173,10 +178,16 @@ class Security_Update_Monitor {
 			return \array_values( \array_unique( $emails ) );
 		}
 
+		// Only the addresses are needed; this can run on a front-end cron request.
 		$emails = [];
-		foreach ( \get_users( [ 'capability' => 'update_core' ] ) as $user ) {
-			if ( $user instanceof \WP_User ) {
-				$emails[] = $user->user_email;
+		foreach ( \get_users(
+			[
+				'capability' => 'update_core',
+				'fields'     => 'user_email',
+			]
+		) as $email ) {
+			if ( \is_string( $email ) && '' !== $email ) {
+				$emails[] = $email;
 			}
 		}
 
@@ -306,41 +317,24 @@ class Security_Update_Monitor {
 	}
 
 	/**
-	 * Get the effective installed WordPress version.
-	 *
-	 * Returns the higher of the running version and the version recorded by the
-	 * last update check (the transient's version_checked), so a just-installed
-	 * update is recognized as soon as the update check has run.
-	 *
-	 * @return string
-	 */
-	public static function get_effective_installed_version() {
-		$installed = self::get_installed_version();
-		$transient = \get_site_transient( 'update_core' );
-
-		if ( \is_object( $transient )
-			&& isset( $transient->version_checked )
-			&& \is_string( $transient->version_checked )
-			&& \version_compare( $transient->version_checked, $installed, '>' )
-		) {
-			return $transient->version_checked;
-		}
-
-		return $installed;
-	}
-
-	/**
 	 * Get the installed WordPress version.
 	 *
 	 * @return string
 	 */
-	private static function get_installed_version() {
+	public static function get_installed_version() {
 		// wp_get_wp_version() exists since WP 6.7; the plugin supports 6.6.
-		if ( \function_exists( 'wp_get_wp_version' ) ) {
-			return \wp_get_wp_version();
-		}
+		$version = \function_exists( 'wp_get_wp_version' )
+			? \wp_get_wp_version()
+			: ( isset( $GLOBALS['wp_version'] ) && \is_string( $GLOBALS['wp_version'] ) ? $GLOBALS['wp_version'] : '' );
 
-		return isset( $GLOBALS['wp_version'] ) && \is_string( $GLOBALS['wp_version'] ) ? $GLOBALS['wp_version'] : '';
+		/**
+		 * Filter the WordPress version the security-update detection treats as installed.
+		 *
+		 * Intended for debugging and testing (e.g. simulating a security release).
+		 *
+		 * @param string $version The running WordPress version.
+		 */
+		return (string) \apply_filters( 'progress_planner_installed_wp_version', $version );
 	}
 
 	/**

--- a/classes/utils/class-security-update-monitor.php
+++ b/classes/utils/class-security-update-monitor.php
@@ -231,9 +231,12 @@ This alert was sent by the Progress Planner plugin.',
 
 		$offered = null;
 		foreach ( $transient->updates as $update ) {
+			// Same-branch point releases are offered with response "autoupdate" (only the
+			// newest release gets "upgrade"), so a branch-behind site (e.g. 6.9.1 when
+			// 7.0.x is current) receives its 6.9.x security patch as an autoupdate offer.
 			if ( ! \is_object( $update )
 				|| ! isset( $update->response, $update->current )
-				|| 'upgrade' !== $update->response
+				|| ! \in_array( $update->response, [ 'upgrade', 'autoupdate' ], true )
 				|| ! \is_string( $update->current )
 				|| ! self::is_security_release( $installed, $update->current )
 			) {

--- a/classes/utils/class-system-status.php
+++ b/classes/utils/class-system-status.php
@@ -33,7 +33,7 @@ class System_Status {
 			'pending'              => null !== $security_update,
 			'installed_version'    => null !== $security_update
 				? $security_update['installed']
-				: Security_Update_Monitor::get_effective_installed_version(),
+				: Security_Update_Monitor::get_installed_version(),
 			'offered_version'      => null !== $security_update ? $security_update['offered'] : null,
 			'last_alerted_version' => (string) \get_site_option( Security_Update_Monitor::ALERTED_VERSION_OPTION, '' ),
 		];

--- a/classes/utils/class-system-status.php
+++ b/classes/utils/class-system-status.php
@@ -9,6 +9,7 @@ namespace Progress_Planner\Utils;
 
 use Progress_Planner\Base;
 use Progress_Planner\Admin\Widgets\Activity_Scores;
+use Progress_Planner\Utils\Security_Update_Monitor;
 
 /**
  * System_Status class.
@@ -25,6 +26,17 @@ class System_Status {
 
 		// Get the number of pending updates.
 		$data['pending_updates'] = \wp_get_update_data()['counts']['total'];
+
+		// Pending WordPress core security update, if any.
+		$security_update          = Security_Update_Monitor::get_pending_security_update();
+		$data['security_updates'] = [
+			'pending'              => null !== $security_update,
+			'installed_version'    => null !== $security_update
+				? $security_update['installed']
+				: Security_Update_Monitor::get_effective_installed_version(),
+			'offered_version'      => null !== $security_update ? $security_update['offered'] : null,
+			'last_alerted_version' => (string) \get_site_option( Security_Update_Monitor::ALERTED_VERSION_OPTION, '' ),
+		];
 
 		// Get number of content from any public post-type, published in the past week.
 		$data['weekly_posts'] = \count(

--- a/tests/phpunit/test-class-security-update-monitor.php
+++ b/tests/phpunit/test-class-security-update-monitor.php
@@ -92,6 +92,39 @@ class Security_Update_Monitor_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the real API shape for a branch-behind site: the same-branch patch is
+	 * only offered with response "autoupdate" once a newer major exists.
+	 *
+	 * A 6.9.1 site gets: upgrade 7.0.4, autoupdate 7.0.4, autoupdate 6.9.7.
+	 */
+	public function test_get_pending_security_update_detects_autoupdate_offer_on_older_branch() {
+		$transient = (object) [
+			'updates' => [
+				(object) [
+					'response' => 'upgrade',
+					'current'  => '7.0.4',
+				],
+				(object) [
+					'response' => 'autoupdate',
+					'current'  => '7.0.4',
+				],
+				(object) [
+					'response' => 'autoupdate',
+					'current'  => '6.9.7',
+				],
+			],
+		];
+
+		$this->assertSame(
+			[
+				'installed' => '6.9.1',
+				'offered'   => '6.9.7',
+			],
+			Security_Update_Monitor::get_pending_security_update( $transient, '6.9.1' )
+		);
+	}
+
+	/**
 	 * Test that non-upgrade offers are ignored.
 	 */
 	public function test_get_pending_security_update_ignores_non_upgrade_offers() {

--- a/tests/phpunit/test-class-security-update-monitor.php
+++ b/tests/phpunit/test-class-security-update-monitor.php
@@ -161,36 +161,10 @@ class Security_Update_Monitor_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that maybe_alert pings the SaaS when a license key is present.
+	 * Test that maybe_alert makes no HTTP requests (subscriber email is feed-driven, SaaS-side).
 	 */
-	public function test_maybe_alert_pings_saas_when_license_key_present() {
+	public function test_maybe_alert_makes_no_http_requests() {
 		\update_option( 'progress_planner_license_key', 'test-license-key' );
-		$this->capture_mails();
-		$requests = $this->capture_http_requests();
-
-		( new Security_Update_Monitor() )->maybe_alert( $this->get_security_transient() );
-
-		$alert_requests = \array_values(
-			\array_filter(
-				$requests->calls,
-				static function ( $request ) {
-					return false !== \strpos( $request['url'], 'security-update-alert' );
-				}
-			)
-		);
-
-		$this->assertCount( 1, $alert_requests );
-		$this->assertSame( 'test-license-key', $alert_requests[0]['body']['license_key'] );
-		$this->assertSame( $this->get_offered_version(), $alert_requests[0]['body']['offered_version'] );
-		$this->assertArrayHasKey( 'installed_version', $alert_requests[0]['body'] );
-		$this->assertArrayHasKey( 'site', $alert_requests[0]['body'] );
-	}
-
-	/**
-	 * Test that the SaaS ping is skipped without a license key.
-	 */
-	public function test_maybe_alert_skips_ping_without_license_key() {
-		\delete_option( 'progress_planner_license_key' );
 		$this->capture_mails();
 		$requests = $this->capture_http_requests();
 
@@ -285,18 +259,6 @@ class Security_Update_Monitor_Test extends \WP_UnitTestCase {
 		\add_filter(
 			'pre_http_request',
 			static function ( $pre, $args, $url ) use ( $recorder ) {
-				if ( false !== \strpos( $url, 'get-nonce' ) ) {
-					return [
-						'headers'  => [],
-						'response' => [
-							'code'    => 200,
-							'message' => 'OK',
-						],
-						'body'     => (string) \wp_json_encode( [ 'nonce' => 'remote-nonce' ] ),
-						'cookies'  => [],
-					];
-				}
-
 				$recorder->calls[] = [
 					'url'  => $url,
 					'body' => isset( $args['body'] ) ? $args['body'] : [],

--- a/tests/phpunit/test-class-security-update-monitor.php
+++ b/tests/phpunit/test-class-security-update-monitor.php
@@ -209,6 +209,23 @@ class Security_Update_Monitor_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that onboarded sites are sent to the Progress Planner dashboard,
+	 * where the one-click branch-pinned update button lives.
+	 */
+	public function test_alert_email_links_to_dashboard_when_onboarded() {
+		\update_option( 'progress_planner_license_key', 'test-license-key' );
+		$mails = $this->capture_mails();
+
+		( new Security_Update_Monitor() )->maybe_alert( $this->get_security_transient() );
+
+		$this->assertNotEmpty( $mails->calls );
+		$message = $mails->calls[0]['message'];
+		$this->assertStringContainsString( \admin_url( 'admin.php?page=progress-planner' ), $message );
+		$this->assertStringContainsString( 'one-click', $message );
+		$this->assertStringNotContainsString( \admin_url( 'update-core.php' ), $message );
+	}
+
+	/**
 	 * Test that maybe_alert makes no HTTP requests (subscriber email is feed-driven, SaaS-side).
 	 */
 	public function test_maybe_alert_makes_no_http_requests() {

--- a/tests/phpunit/test-class-security-update-monitor.php
+++ b/tests/phpunit/test-class-security-update-monitor.php
@@ -203,6 +203,9 @@ class Security_Update_Monitor_Test extends \WP_UnitTestCase {
 		$mail = $mails->calls[0];
 		$this->assertStringContainsString( $this->get_offered_version(), $mail['subject'] . $mail['message'] );
 		$this->assertStringContainsString( \admin_url( 'update-core.php' ), $mail['message'] );
+		// The backup advice must be present, but phrased not to delay the update.
+		$this->assertStringContainsString( 'backup', $mail['message'] );
+		$this->assertStringContainsString( 'https://wordpress.org/documentation/article/wordpress-backups/', $mail['message'] );
 	}
 
 	/**

--- a/tests/phpunit/test-class-security-update-monitor.php
+++ b/tests/phpunit/test-class-security-update-monitor.php
@@ -1,0 +1,364 @@
+<?php
+/**
+ * Class Security_Update_Monitor_Test
+ *
+ * @package Progress_Planner\Tests
+ */
+
+namespace Progress_Planner\Tests;
+
+use Progress_Planner\Utils\Security_Update_Monitor;
+
+/**
+ * Security update detection test case.
+ */
+class Security_Update_Monitor_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Data provider for is_security_release.
+	 *
+	 * @return array<string, array{string, string, bool}>
+	 */
+	public function data_is_security_release() {
+		return [
+			'patch release'                  => [ '6.8.1', '6.8.2', true ],
+			'first patch on a new branch'    => [ '6.8', '6.8.1', true ],
+			'patch jump of several versions' => [ '6.8.1', '6.8.4', true ],
+			'new major.minor'                => [ '6.7.2', '6.8.0', false ],
+			'cross-branch jump'              => [ '6.7.2', '6.8.2', false ],
+			'same version'                   => [ '6.8.2', '6.8.2', false ],
+			'downgrade'                      => [ '6.8.2', '6.8.1', false ],
+			'installed alpha build'          => [ '6.9-alpha-59000', '6.9.1', false ],
+			'offered release candidate'      => [ '6.8.1', '6.9-RC1', false ],
+			'malformed offered version'      => [ '6.8.1', 'not-a-version', false ],
+			'empty installed version'        => [ '', '6.8.2', false ],
+		];
+	}
+
+	/**
+	 * Test the is_security_release version heuristic.
+	 *
+	 * @dataProvider data_is_security_release
+	 *
+	 * @param string $installed The installed version.
+	 * @param string $offered   The offered version.
+	 * @param bool   $expected  The expected result.
+	 */
+	public function test_is_security_release( $installed, $offered, $expected ) {
+		$this->assertSame( $expected, Security_Update_Monitor::is_security_release( $installed, $offered ) );
+	}
+
+	/**
+	 * Test that get_pending_security_update picks the same-branch patch from a multi-offer transient.
+	 */
+	public function test_get_pending_security_update_picks_same_branch_patch() {
+		$result = Security_Update_Monitor::get_pending_security_update(
+			$this->get_mock_transient( [ '6.9.0', '6.8.2' ] ),
+			'6.8.1'
+		);
+
+		$this->assertSame(
+			[
+				'installed' => '6.8.1',
+				'offered'   => '6.8.2',
+			],
+			$result
+		);
+	}
+
+	/**
+	 * Test that get_pending_security_update returns the highest matching patch.
+	 */
+	public function test_get_pending_security_update_returns_highest_patch() {
+		$result = Security_Update_Monitor::get_pending_security_update(
+			$this->get_mock_transient( [ '6.8.2', '6.8.3' ] ),
+			'6.8.1'
+		);
+
+		$this->assertNotNull( $result );
+		$this->assertSame( '6.8.3', $result['offered'] );
+	}
+
+	/**
+	 * Test that a feature release does not register as a security update.
+	 */
+	public function test_get_pending_security_update_ignores_feature_release() {
+		$this->assertNull(
+			Security_Update_Monitor::get_pending_security_update(
+				$this->get_mock_transient( [ '6.9.0' ] ),
+				'6.8.2'
+			)
+		);
+	}
+
+	/**
+	 * Test that non-upgrade offers are ignored.
+	 */
+	public function test_get_pending_security_update_ignores_non_upgrade_offers() {
+		$transient = $this->get_mock_transient( [ '6.8.2' ] );
+
+		$transient->updates[0]->response = 'latest';
+
+		$this->assertNull( Security_Update_Monitor::get_pending_security_update( $transient, '6.8.1' ) );
+	}
+
+	/**
+	 * Test that malformed transients are handled gracefully.
+	 */
+	public function test_get_pending_security_update_handles_malformed_transient() {
+		$this->assertNull( Security_Update_Monitor::get_pending_security_update( null, '6.8.1' ) );
+		$this->assertNull( Security_Update_Monitor::get_pending_security_update( new \stdClass(), '6.8.1' ) );
+		$this->assertNull( Security_Update_Monitor::get_pending_security_update( (object) [ 'updates' => 'nope' ], '6.8.1' ) );
+	}
+
+	/**
+	 * Test that maybe_alert emails all update_core users exactly once per offered version.
+	 */
+	public function test_maybe_alert_sends_email_to_admins_once_per_version() {
+		$admin_id  = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		$mails     = $this->capture_mails();
+
+		$monitor = new Security_Update_Monitor();
+		$monitor->maybe_alert( $this->get_security_transient() );
+
+		$expected_recipients = [];
+		foreach ( \get_users( [ 'capability' => 'update_core' ] ) as $user ) {
+			$expected_recipients[] = $user->user_email;
+		}
+		\sort( $expected_recipients );
+
+		$actual_recipients = \array_column( $mails->calls, 'to' );
+		\sort( $actual_recipients );
+
+		$this->assertNotEmpty( $expected_recipients );
+		$this->assertSame( $expected_recipients, $actual_recipients );
+		$this->assertNotContains( \get_user_by( 'id', $editor_id )->user_email, $actual_recipients );
+		$this->assertContains( \get_user_by( 'id', $admin_id )->user_email, $actual_recipients );
+
+		// Second call with the same offered version must not send again.
+		$mails->calls = [];
+		$monitor->maybe_alert( $this->get_security_transient() );
+		$this->assertSame( [], $mails->calls );
+
+		// A newer offered version must alert again.
+		$monitor->maybe_alert( $this->get_security_transient( 2 ) );
+		$this->assertNotEmpty( $mails->calls );
+	}
+
+	/**
+	 * Test that the alert email names the offered version and links to the updates page.
+	 */
+	public function test_alert_email_contains_version_and_update_link() {
+		$mails = $this->capture_mails();
+
+		( new Security_Update_Monitor() )->maybe_alert( $this->get_security_transient() );
+
+		$this->assertNotEmpty( $mails->calls );
+		$mail = $mails->calls[0];
+		$this->assertStringContainsString( $this->get_offered_version(), $mail['subject'] . $mail['message'] );
+		$this->assertStringContainsString( \admin_url( 'update-core.php' ), $mail['message'] );
+	}
+
+	/**
+	 * Test that maybe_alert pings the SaaS when a license key is present.
+	 */
+	public function test_maybe_alert_pings_saas_when_license_key_present() {
+		\update_option( 'progress_planner_license_key', 'test-license-key' );
+		$this->capture_mails();
+		$requests = $this->capture_http_requests();
+
+		( new Security_Update_Monitor() )->maybe_alert( $this->get_security_transient() );
+
+		$alert_requests = \array_values(
+			\array_filter(
+				$requests->calls,
+				static function ( $request ) {
+					return false !== \strpos( $request['url'], 'security-update-alert' );
+				}
+			)
+		);
+
+		$this->assertCount( 1, $alert_requests );
+		$this->assertSame( 'test-license-key', $alert_requests[0]['body']['license_key'] );
+		$this->assertSame( $this->get_offered_version(), $alert_requests[0]['body']['offered_version'] );
+		$this->assertArrayHasKey( 'installed_version', $alert_requests[0]['body'] );
+		$this->assertArrayHasKey( 'site', $alert_requests[0]['body'] );
+	}
+
+	/**
+	 * Test that the SaaS ping is skipped without a license key.
+	 */
+	public function test_maybe_alert_skips_ping_without_license_key() {
+		\delete_option( 'progress_planner_license_key' );
+		$this->capture_mails();
+		$requests = $this->capture_http_requests();
+
+		( new Security_Update_Monitor() )->maybe_alert( $this->get_security_transient() );
+
+		$this->assertSame( [], $requests->calls );
+	}
+
+	/**
+	 * Test that maybe_alert ignores feature releases.
+	 */
+	public function test_maybe_alert_ignores_feature_releases() {
+		$mails = $this->capture_mails();
+
+		$parts     = \explode( '.', \wp_get_wp_version() );
+		$transient = $this->get_mock_transient( [ $parts[0] . '.' . ( (int) $parts[1] + 1 ) . '.0' ] );
+
+		( new Security_Update_Monitor() )->maybe_alert( $transient );
+
+		$this->assertSame( [], $mails->calls );
+		$this->assertFalse( \get_site_option( 'progress_planner_security_update_alerted_version' ) );
+	}
+
+	/**
+	 * Test that the plugin bootstrap registers the monitor's detection hooks.
+	 */
+	public function test_monitor_hooks_are_registered_on_boot() {
+		$monitor = \progress_planner()->get_utils__security_update_monitor();
+
+		$this->assertInstanceOf( Security_Update_Monitor::class, $monitor );
+		$this->assertNotFalse( \has_action( 'set_site_transient_update_core', [ $monitor, 'maybe_alert' ] ) );
+		$this->assertNotFalse( \has_action( 'admin_init', [ $monitor, 'maybe_alert_from_stored_transient' ] ) );
+	}
+
+	/**
+	 * Test that the system status exposes the pending security update to the SaaS.
+	 */
+	public function test_system_status_exposes_security_updates() {
+		\set_site_transient( 'update_core', $this->get_security_transient() );
+		\update_site_option( 'progress_planner_security_update_alerted_version', $this->get_offered_version() );
+
+		$status = ( new \Progress_Planner\Utils\System_Status() )->get_system_status();
+
+		$this->assertArrayHasKey( 'security_updates', $status );
+		$this->assertTrue( $status['security_updates']['pending'] );
+		$this->assertSame( $this->get_offered_version(), $status['security_updates']['offered_version'] );
+		$this->assertSame( $this->get_offered_version(), $status['security_updates']['last_alerted_version'] );
+		$this->assertNotSame( '', $status['security_updates']['installed_version'] );
+	}
+
+	/**
+	 * Test the system status without a pending security update.
+	 */
+	public function test_system_status_without_security_update() {
+		\delete_site_transient( 'update_core' );
+
+		$status = ( new \Progress_Planner\Utils\System_Status() )->get_system_status();
+
+		$this->assertFalse( $status['security_updates']['pending'] );
+		$this->assertNull( $status['security_updates']['offered_version'] );
+	}
+
+	/**
+	 * Capture outgoing mails via the pre_wp_mail short-circuit.
+	 *
+	 * @return object The recorder; captured calls in ->calls.
+	 */
+	private function capture_mails() {
+		$recorder        = new \stdClass();
+		$recorder->calls = [];
+		\add_filter(
+			'pre_wp_mail',
+			static function ( $pre, $atts ) use ( $recorder ) {
+				$recorder->calls[] = $atts;
+				return true;
+			},
+			10,
+			2
+		);
+
+		return $recorder;
+	}
+
+	/**
+	 * Capture outgoing HTTP requests via the pre_http_request short-circuit.
+	 *
+	 * @return object The recorder; captured calls in ->calls.
+	 */
+	private function capture_http_requests() {
+		$recorder        = new \stdClass();
+		$recorder->calls = [];
+		\add_filter(
+			'pre_http_request',
+			static function ( $pre, $args, $url ) use ( $recorder ) {
+				if ( false !== \strpos( $url, 'get-nonce' ) ) {
+					return [
+						'headers'  => [],
+						'response' => [
+							'code'    => 200,
+							'message' => 'OK',
+						],
+						'body'     => (string) \wp_json_encode( [ 'nonce' => 'remote-nonce' ] ),
+						'cookies'  => [],
+					];
+				}
+
+				$recorder->calls[] = [
+					'url'  => $url,
+					'body' => isset( $args['body'] ) ? $args['body'] : [],
+				];
+
+				return [
+					'headers'  => [],
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => (string) \wp_json_encode( [ 'status' => 'ok' ] ),
+					'cookies'  => [],
+				];
+			},
+			10,
+			3
+		);
+
+		return $recorder;
+	}
+
+	/**
+	 * Get an offered patch version relative to the running WordPress version.
+	 *
+	 * @param int $bump How many patch versions to bump.
+	 *
+	 * @return string
+	 */
+	private function get_offered_version( $bump = 1 ) {
+		$parts = \explode( '.', \wp_get_wp_version() );
+
+		return $parts[0] . '.' . $parts[1] . '.' . ( isset( $parts[2] ) ? (int) $parts[2] + $bump : $bump );
+	}
+
+	/**
+	 * Build a transient offering a security release for the running WordPress version.
+	 *
+	 * @param int $bump How many patch versions to bump.
+	 *
+	 * @return \stdClass
+	 */
+	private function get_security_transient( $bump = 1 ) {
+		return $this->get_mock_transient( [ $this->get_offered_version( $bump ) ] );
+	}
+
+	/**
+	 * Build a mock update_core transient object.
+	 *
+	 * @param string[] $offered_versions The offered versions.
+	 *
+	 * @return \stdClass
+	 */
+	private function get_mock_transient( $offered_versions ) {
+		$updates = [];
+		foreach ( $offered_versions as $version ) {
+			$updates[] = (object) [
+				'response' => 'upgrade',
+				'current'  => $version,
+			];
+		}
+
+		return (object) [ 'updates' => $updates ];
+	}
+}

--- a/tests/phpunit/test-class-security-update-monitor.php
+++ b/tests/phpunit/test-class-security-update-monitor.php
@@ -226,6 +226,26 @@ class Security_Update_Monitor_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a stale lock is cleared without sending, and the next call sends normally.
+	 *
+	 * Two requests hitting a stale lock must not both send; the first clears it and
+	 * bails, the next takes a fresh atomic lock.
+	 */
+	public function test_stale_lock_is_cleared_and_next_call_sends() {
+		$mails = $this->capture_mails();
+		\update_site_option( Security_Update_Monitor::LOCK_OPTION, \time() - 60 );
+
+		$monitor = new Security_Update_Monitor();
+		$monitor->maybe_alert( $this->get_security_transient() );
+
+		$this->assertSame( [], $mails->calls );
+		$this->assertFalse( \get_site_option( Security_Update_Monitor::LOCK_OPTION ) );
+
+		$monitor->maybe_alert( $this->get_security_transient() );
+		$this->assertNotEmpty( $mails->calls );
+	}
+
+	/**
 	 * Test that maybe_alert makes no HTTP requests (subscriber email is feed-driven, SaaS-side).
 	 */
 	public function test_maybe_alert_makes_no_http_requests() {

--- a/tests/phpunit/test-class-security-update-monitor.php
+++ b/tests/phpunit/test-class-security-update-monitor.php
@@ -122,9 +122,19 @@ class Security_Update_Monitor_Test extends \WP_UnitTestCase {
 		$monitor = new Security_Update_Monitor();
 		$monitor->maybe_alert( $this->get_security_transient() );
 
+		// On multisite only super admins can update core; on single site, all update_core users.
 		$expected_recipients = [];
-		foreach ( \get_users( [ 'capability' => 'update_core' ] ) as $user ) {
-			$expected_recipients[] = $user->user_email;
+		if ( \is_multisite() ) {
+			foreach ( \get_super_admins() as $login ) {
+				$user = \get_user_by( 'login', $login );
+				if ( $user ) {
+					$expected_recipients[] = $user->user_email;
+				}
+			}
+		} else {
+			foreach ( \get_users( [ 'capability' => 'update_core' ] ) as $user ) {
+				$expected_recipients[] = $user->user_email;
+			}
 		}
 		\sort( $expected_recipients );
 
@@ -134,7 +144,9 @@ class Security_Update_Monitor_Test extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $expected_recipients );
 		$this->assertSame( $expected_recipients, $actual_recipients );
 		$this->assertNotContains( \get_user_by( 'id', $editor_id )->user_email, $actual_recipients );
-		$this->assertContains( \get_user_by( 'id', $admin_id )->user_email, $actual_recipients );
+		if ( ! \is_multisite() ) {
+			$this->assertContains( \get_user_by( 'id', $admin_id )->user_email, $actual_recipients );
+		}
 
 		// Second call with the same offered version must not send again.
 		$mails->calls = [];

--- a/tests/phpunit/test-class-security-update-provider.php
+++ b/tests/phpunit/test-class-security-update-provider.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Class Security_Update_Provider_Test
+ *
+ * @package Progress_Planner\Tests
+ */
+
+namespace Progress_Planner\Tests;
+
+/**
+ * Security update task provider test case.
+ */
+class Security_Update_Provider_Test extends \WP_UnitTestCase {
+
+	use Task_Provider_Test_Trait {
+		set_up as protected trait_set_up;
+	}
+
+	/**
+	 * The task provider ID.
+	 *
+	 * @var string
+	 */
+	protected $task_provider_id = 'security-update';
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		$this->set_security_offer();
+		$this->trait_set_up();
+
+		// The current user is reset between tests; capability checks need the admin.
+		\wp_set_current_user( 1 );
+	}
+
+	/**
+	 * Complete the task.
+	 *
+	 * @return void
+	 */
+	protected function complete_task() {
+		// Simulate the update being installed: the refreshed transient reports the
+		// new version as installed and no longer offers an upgrade.
+		\set_site_transient(
+			'update_core',
+			(object) [
+				'updates'         => [],
+				'version_checked' => $this->get_offered_version(),
+			]
+		);
+	}
+
+	/**
+	 * Test that the task ID carries the offered version.
+	 */
+	public function test_task_id_is_versioned() {
+		$expected = 'security-update-' . \str_replace( '.', '-', $this->get_offered_version() );
+		$this->assertSame( $expected, $this->task_provider->get_task_id() );
+	}
+
+	/**
+	 * Test that the task is neither dismissable nor snoozable and has top priority.
+	 */
+	public function test_task_is_locked_to_highest_urgency() {
+		$this->assertFalse( $this->task_provider->is_dismissable() );
+		$this->assertFalse( $this->task_provider->is_snoozable() );
+		$this->assertSame( 0, $this->task_provider->get_priority() );
+	}
+
+	/**
+	 * Test that a superseded offer replaces the published task.
+	 */
+	public function test_superseded_offer_replaces_task() {
+		$this->task_provider->get_tasks_to_inject();
+		$first_task_id = $this->task_provider->get_task_id();
+
+		// A newer patch release supersedes the first one.
+		$this->set_security_offer( 2 );
+		$this->task_provider->get_tasks_to_inject();
+
+		$tasks = (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'post_status' => 'publish',
+				'provider'    => $this->task_provider_id,
+			]
+		);
+
+		$this->assertCount( 1, $tasks );
+		$this->assertSame( $this->task_provider->get_task_id(), $tasks[0]->post_name );
+		$this->assertNotSame( $first_task_id, $tasks[0]->post_name );
+	}
+
+	/**
+	 * Test that a withdrawn offer deletes the published task without celebration.
+	 */
+	public function test_withdrawn_offer_deletes_task() {
+		$this->task_provider->get_tasks_to_inject();
+
+		// The offer is withdrawn; the installed version did not change.
+		\set_site_transient( 'update_core', (object) [ 'updates' => [] ] );
+
+		$completed = \progress_planner()->get_suggested_tasks()->get_tasks_manager()->evaluate_tasks();
+
+		$this->assertSame( [], $completed );
+		$this->assertSame(
+			[],
+			(array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+				[
+					'post_status' => 'publish',
+					'provider'    => $this->task_provider_id,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Test that a new security release is injected even after an older one was completed.
+	 */
+	public function test_new_release_injected_after_previous_completion() {
+		$this->task_provider->get_tasks_to_inject();
+
+		// Complete the first task.
+		$tasks = (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'post_status' => 'publish',
+				'provider'    => $this->task_provider_id,
+			]
+		);
+		\progress_planner()->get_suggested_tasks_db()->update_recommendation( $tasks[0]->ID, [ 'post_status' => 'trash' ] );
+
+		// A newer security release appears.
+		$this->set_security_offer( 2 );
+		$this->task_provider->get_tasks_to_inject();
+
+		$tasks = (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'post_status' => 'publish',
+				'provider'    => $this->task_provider_id,
+			]
+		);
+
+		$this->assertCount( 1, $tasks );
+		$this->assertSame( $this->task_provider->get_task_id(), $tasks[0]->post_name );
+	}
+
+	/**
+	 * Test that a published security task hides all other tasks from the REST-format list.
+	 */
+	public function test_lockdown_limits_rest_format_to_security_task() {
+		$this->add_other_task();
+
+		// Without a published security task, the other task is listed.
+		$tasks = \progress_planner()->get_suggested_tasks()->get_tasks_in_rest_format( [ 'post_status' => 'publish' ] );
+		$this->assertCount( 1, $tasks );
+
+		$this->task_provider->get_tasks_to_inject();
+		\wp_cache_flush();
+
+		$tasks = \progress_planner()->get_suggested_tasks()->get_tasks_in_rest_format( [ 'post_status' => 'publish' ] );
+
+		$this->assertCount( 1, $tasks );
+		$this->assertSame( $this->task_provider->get_task_id(), $tasks[0]['slug'] );
+	}
+
+	/**
+	 * Test that the lockdown leaves non-publish statuses (celebrations, user tasks) alone.
+	 */
+	public function test_lockdown_does_not_affect_pending_celebration_tasks() {
+		// Celebration tasks transition publish → pending in production, keeping their slug.
+		$other_task_id = \progress_planner()->get_suggested_tasks_db()->add(
+			[
+				'task_id'     => 'core-blogdescription',
+				'provider_id' => 'core-blogdescription',
+				'post_title'  => 'Celebrate me',
+				'post_status' => 'publish',
+				'url'         => \admin_url( 'options-general.php' ),
+			]
+		);
+		\progress_planner()->get_suggested_tasks_db()->update_recommendation( $other_task_id, [ 'post_status' => 'pending' ] );
+		$this->task_provider->get_tasks_to_inject();
+		\wp_cache_flush();
+
+		$tasks = \progress_planner()->get_suggested_tasks()->get_tasks_in_rest_format( [ 'post_status' => 'pending' ] );
+
+		$this->assertCount( 1, $tasks );
+		$this->assertSame( 'core-blogdescription', $tasks[0]['slug'] );
+	}
+
+	/**
+	 * Test that the REST collection query is constrained to the security provider under lockdown.
+	 */
+	public function test_lockdown_forces_rest_tax_query_to_security_provider() {
+		$this->task_provider->get_tasks_to_inject();
+
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/prpl_recommendations' );
+		$args    = \progress_planner()->get_suggested_tasks()->rest_api_tax_query( [], $request );
+
+		$this->assertSame( [ 'security-update' ], $this->get_tax_query_include_terms( $args ) );
+	}
+
+	/**
+	 * Test that users who cannot install updates keep their normal task list.
+	 */
+	public function test_lockdown_skips_users_without_update_capability() {
+		$this->task_provider->get_tasks_to_inject();
+
+		$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		\wp_set_current_user( $editor_id );
+
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/prpl_recommendations' );
+		$args    = \progress_planner()->get_suggested_tasks()->rest_api_tax_query( [], $request );
+		$terms   = $this->get_tax_query_include_terms( $args );
+
+		\wp_set_current_user( 1 );
+
+		$this->assertNotSame( [ 'security-update' ], $terms );
+		$this->assertNotEmpty( $terms );
+	}
+
+	/**
+	 * Test that automatic core updates complete the security task without celebration.
+	 */
+	public function test_automatic_update_completes_security_task() {
+		$this->task_provider->get_tasks_to_inject();
+
+		$tasks = (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'post_status' => 'publish',
+				'provider'    => $this->task_provider_id,
+			]
+		);
+		$this->assertCount( 1, $tasks );
+
+		\progress_planner()->get_suggested_tasks()->on_automatic_updates_complete();
+
+		$this->assertSame( 'trash', \get_post_status( $tasks[0]->ID ) );
+	}
+
+	/**
+	 * Add a published task from another provider.
+	 *
+	 * @return void
+	 */
+	private function add_other_task() {
+		\progress_planner()->get_suggested_tasks_db()->add(
+			[
+				'task_id'     => 'core-blogdescription',
+				'provider_id' => 'core-blogdescription',
+				'post_title'  => 'Set your tagline',
+				'post_status' => 'publish',
+				'url'         => \admin_url( 'options-general.php' ),
+			]
+		);
+		\wp_cache_flush();
+	}
+
+	/**
+	 * Extract the IN-operator provider terms from REST query args.
+	 *
+	 * @param array $args The query args returned by rest_api_tax_query().
+	 *
+	 * @return array
+	 */
+	private function get_tax_query_include_terms( $args ) {
+		foreach ( (array) ( $args['tax_query'] ?? [] ) as $clause ) {
+			if ( \is_array( $clause ) && isset( $clause['operator'] ) && 'IN' === $clause['operator'] ) {
+				return \array_values( (array) $clause['terms'] );
+			}
+		}
+
+		return [];
+	}
+
+	/**
+	 * Get an offered patch version relative to the running WordPress version.
+	 *
+	 * @param int $bump How many patch versions to bump.
+	 *
+	 * @return string
+	 */
+	private function get_offered_version( $bump = 1 ) {
+		$parts = \explode( '.', \wp_get_wp_version() );
+
+		return $parts[0] . '.' . $parts[1] . '.' . ( isset( $parts[2] ) ? (int) $parts[2] + $bump : $bump );
+	}
+
+	/**
+	 * Store an update_core transient offering a security release.
+	 *
+	 * @param int $bump How many patch versions to bump.
+	 *
+	 * @return void
+	 */
+	private function set_security_offer( $bump = 1 ) {
+		\set_site_transient(
+			'update_core',
+			(object) [
+				'updates' => [
+					(object) [
+						'response' => 'upgrade',
+						'current'  => $this->get_offered_version( $bump ),
+					],
+				],
+			]
+		);
+	}
+}

--- a/tests/phpunit/test-class-security-update-provider.php
+++ b/tests/phpunit/test-class-security-update-provider.php
@@ -240,6 +240,16 @@ class Security_Update_Provider_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the task description recommends a backup without inviting delay.
+	 */
+	public function test_task_description_recommends_backup() {
+		$description = $this->task_provider->get_task_details()['description'];
+
+		$this->assertStringContainsString( 'backup', $description );
+		$this->assertStringContainsString( 'postpone', $description );
+	}
+
+	/**
 	 * Test that the task actions include a form that updates to the branch version directly.
 	 *
 	 * The wp-admin Updates page only shows the latest major (get_core_updates() skips

--- a/tests/phpunit/test-class-security-update-provider.php
+++ b/tests/phpunit/test-class-security-update-provider.php
@@ -42,15 +42,30 @@ class Security_Update_Provider_Test extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	protected function complete_task() {
-		// Simulate the update being installed: the refreshed transient reports the
-		// new version as installed and no longer offers an upgrade.
-		\set_site_transient(
-			'update_core',
-			(object) [
-				'updates'         => [],
-				'version_checked' => $this->get_offered_version(),
-			]
+		// Simulate the update being installed: the running version becomes the
+		// offered one (via the installed-version filter) and the refreshed
+		// transient no longer offers an upgrade.
+		$offered = $this->get_offered_version();
+		\add_filter(
+			'progress_planner_installed_wp_version',
+			static function () use ( $offered ) {
+				return $offered;
+			}
 		);
+		\set_site_transient( 'update_core', (object) [ 'updates' => [] ] );
+	}
+
+	/**
+	 * Test that installing the update completes the task through evaluation.
+	 */
+	public function test_task_completes_after_update_is_installed() {
+		$this->task_provider->get_tasks_to_inject();
+		$this->complete_task();
+
+		$completed = \progress_planner()->get_suggested_tasks()->get_tasks_manager()->evaluate_tasks();
+
+		$this->assertCount( 1, $completed );
+		$this->assertSame( $this->task_provider_id, $completed[0]->get_provider_id() );
 	}
 
 	/**
@@ -157,7 +172,6 @@ class Security_Update_Provider_Test extends \WP_UnitTestCase {
 		$this->assertCount( 1, $tasks );
 
 		$this->task_provider->get_tasks_to_inject();
-		\wp_cache_flush();
 
 		$tasks = \progress_planner()->get_suggested_tasks()->get_tasks_in_rest_format( [ 'post_status' => 'publish' ] );
 
@@ -181,7 +195,6 @@ class Security_Update_Provider_Test extends \WP_UnitTestCase {
 		);
 		\progress_planner()->get_suggested_tasks_db()->update_recommendation( $other_task_id, [ 'post_status' => 'pending' ] );
 		$this->task_provider->get_tasks_to_inject();
-		\wp_cache_flush();
 
 		$tasks = \progress_planner()->get_suggested_tasks()->get_tasks_in_rest_format( [ 'post_status' => 'pending' ] );
 
@@ -221,10 +234,82 @@ class Security_Update_Provider_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that automatic core updates complete the security task without celebration.
+	 * Test that automatic core updates complete the security task without celebration,
+	 * leaving other providers' tasks untouched.
 	 */
 	public function test_automatic_update_completes_security_task() {
 		$this->task_provider->get_tasks_to_inject();
+		$this->add_other_task();
+
+		$security_tasks = (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'post_status' => 'publish',
+				'provider'    => $this->task_provider_id,
+			]
+		);
+		$other_tasks    = (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'post_status' => 'publish',
+				'provider'    => 'core-blogdescription',
+			]
+		);
+		$this->assertCount( 1, $security_tasks );
+		$this->assertCount( 1, $other_tasks );
+
+		\progress_planner()->get_suggested_tasks()->on_automatic_updates_complete( [ 'core' => [ (object) [ 'result' => true ] ] ] );
+
+		$this->assertSame( 'trash', \get_post_status( $security_tasks[0]->ID ) );
+		$this->assertSame( 'publish', \get_post_status( $other_tasks[0]->ID ) );
+	}
+
+	/**
+	 * Test that plugin/theme-only automatic updates do not complete the security task.
+	 */
+	public function test_plugin_only_automatic_update_does_not_complete_security_task() {
+		$this->task_provider->get_tasks_to_inject();
+
+		$security_tasks = (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'post_status' => 'publish',
+				'provider'    => $this->task_provider_id,
+			]
+		);
+		$this->assertCount( 1, $security_tasks );
+
+		\progress_planner()->get_suggested_tasks()->on_automatic_updates_complete( [ 'plugin' => [ (object) [ 'result' => true ] ] ] );
+
+		$this->assertSame( 'publish', \get_post_status( $security_tasks[0]->ID ) );
+	}
+
+	/**
+	 * Test that automatic updates never touch other providers' tasks when no
+	 * security task exists (regression: provider filter must reach the query).
+	 */
+	public function test_automatic_update_leaves_other_tasks_alone_without_security_task() {
+		\set_site_transient( 'update_core', (object) [ 'updates' => [] ] );
+		$this->add_other_task();
+
+		$other_tasks = (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
+			[
+				'post_status' => 'publish',
+				'provider'    => 'core-blogdescription',
+			]
+		);
+		$this->assertCount( 1, $other_tasks );
+
+		\progress_planner()->get_suggested_tasks()->on_automatic_updates_complete( [ 'core' => [ (object) [ 'result' => true ] ] ] );
+
+		$this->assertSame( 'publish', \get_post_status( $other_tasks[0]->ID ) );
+	}
+
+	/**
+	 * Test that the lockdown lifts as soon as the task is trashed, with no manual cache flush.
+	 */
+	public function test_lockdown_lifts_when_task_is_trashed() {
+		$this->task_provider->get_tasks_to_inject();
+		$monitor = \progress_planner()->get_utils__security_update_monitor();
+
+		$this->assertTrue( $monitor->is_security_lockdown_active() );
 
 		$tasks = (array) \progress_planner()->get_suggested_tasks_db()->get_tasks_by(
 			[
@@ -232,11 +317,9 @@ class Security_Update_Provider_Test extends \WP_UnitTestCase {
 				'provider'    => $this->task_provider_id,
 			]
 		);
-		$this->assertCount( 1, $tasks );
+		\progress_planner()->get_suggested_tasks_db()->update_recommendation( $tasks[0]->ID, [ 'post_status' => 'trash' ] );
 
-		\progress_planner()->get_suggested_tasks()->on_automatic_updates_complete();
-
-		$this->assertSame( 'trash', \get_post_status( $tasks[0]->ID ) );
+		$this->assertFalse( $monitor->is_security_lockdown_active() );
 	}
 
 	/**
@@ -319,7 +402,6 @@ class Security_Update_Provider_Test extends \WP_UnitTestCase {
 				'url'         => \admin_url( 'options-general.php' ),
 			]
 		);
-		\wp_cache_flush();
 	}
 
 	/**

--- a/tests/phpunit/test-class-security-update-provider.php
+++ b/tests/phpunit/test-class-security-update-provider.php
@@ -240,6 +240,61 @@ class Security_Update_Provider_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the task actions include a form that updates to the branch version directly.
+	 *
+	 * The wp-admin Updates page only shows the latest major (get_core_updates() skips
+	 * "autoupdate" offers), so the task must offer the branch-pinned update itself.
+	 */
+	public function test_task_action_contains_branch_pinned_update_form() {
+		$actions = $this->task_provider->add_task_actions( [], [] );
+		$html    = \implode( ' ', \array_column( $actions, 'html' ) );
+
+		$this->assertStringContainsString( 'update-core.php?action=do-core-upgrade', $html );
+		$this->assertStringContainsString( 'name="version" value="' . $this->get_offered_version() . '"', $html );
+		$this->assertStringContainsString( 'name="locale" value="en_US"', $html );
+		$this->assertStringContainsString( 'name="upgrade"', $html );
+		$this->assertStringContainsString( 'name="_wpnonce"', $html );
+		// The fallback link to the Updates page remains.
+		$this->assertStringContainsString( 'Go to the Updates page', $html );
+	}
+
+	/**
+	 * Test that the update form uses the locale of the matched offer.
+	 */
+	public function test_task_action_form_uses_offer_locale() {
+		\set_site_transient(
+			'update_core',
+			(object) [
+				'updates' => [
+					(object) [
+						'response' => 'autoupdate',
+						'current'  => $this->get_offered_version(),
+						'locale'   => 'de_DE',
+					],
+				],
+			]
+		);
+
+		$actions = $this->task_provider->add_task_actions( [], [] );
+		$html    = \implode( ' ', \array_column( $actions, 'html' ) );
+
+		$this->assertStringContainsString( 'name="locale" value="de_DE"', $html );
+	}
+
+	/**
+	 * Test that no update form is rendered without a pending security update.
+	 */
+	public function test_task_action_form_absent_without_pending_update() {
+		\set_site_transient( 'update_core', (object) [ 'updates' => [] ] );
+
+		$actions = $this->task_provider->add_task_actions( [], [] );
+		$html    = \implode( ' ', \array_column( $actions, 'html' ) );
+
+		$this->assertStringNotContainsString( 'do-core-upgrade', $html );
+		$this->assertStringContainsString( 'Go to the Updates page', $html );
+	}
+
+	/**
 	 * Add a published task from another provider.
 	 *
 	 * @return void

--- a/tests/phpunit/test-class-suggested-tasks-db.php
+++ b/tests/phpunit/test-class-suggested-tasks-db.php
@@ -453,4 +453,48 @@ class Suggested_Tasks_Db_Test extends \WP_UnitTestCase {
 		$tasks_2 = $this->db_instance->get();
 		$this->assertEquals( \count( $tasks_1 ), \count( $tasks_2 ) );
 	}
+
+	/**
+	 * Test that adding a task invalidates cached get() results.
+	 *
+	 * @return void
+	 */
+	public function test_add_invalidates_get_cache() {
+		$this->db_instance->add(
+			[
+				'task_id'     => 'cache-test-1',
+				'post_title'  => 'Cache test 1',
+				'provider_id' => 'test-provider',
+			]
+		);
+		$this->assertCount( 1, $this->db_instance->get( [ 'post_status' => 'publish' ] ) );
+
+		$this->db_instance->add(
+			[
+				'task_id'     => 'cache-test-2',
+				'post_title'  => 'Cache test 2',
+				'provider_id' => 'test-provider',
+			]
+		);
+		$this->assertCount( 2, $this->db_instance->get( [ 'post_status' => 'publish' ] ) );
+	}
+
+	/**
+	 * Test that updating a task invalidates cached get() results.
+	 *
+	 * @return void
+	 */
+	public function test_update_invalidates_get_cache() {
+		$post_id = $this->db_instance->add(
+			[
+				'task_id'     => 'cache-test-3',
+				'post_title'  => 'Cache test 3',
+				'provider_id' => 'test-provider',
+			]
+		);
+		$this->assertCount( 1, $this->db_instance->get( [ 'post_status' => 'publish' ] ) );
+
+		$this->db_instance->update_recommendation( $post_id, [ 'post_status' => 'trash' ] );
+		$this->assertCount( 0, $this->db_instance->get( [ 'post_status' => 'publish' ] ) );
+	}
 }

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -23,7 +23,11 @@ if ( ! \defined( 'ABSPATH' ) ) {
 		);
 		?>
 	</h2>
-	<?php if ( \progress_planner()->get_utils__security_update_monitor()->is_security_lockdown_active() && \current_user_can( 'update_core' ) ) : ?>
+	<?php
+	// Same capability gate as the lockdown chokepoints: the provider decides who can act on the task.
+	$prpl_security_provider = \progress_planner()->get_suggested_tasks()->get_tasks_manager()->get_task_provider( 'security-update' );
+	?>
+	<?php if ( $prpl_security_provider && $prpl_security_provider->capability_required() && \progress_planner()->get_utils__security_update_monitor()->is_security_lockdown_active() ) : ?>
 		<p class="prpl-suggested-tasks-widget-description prpl-suggested-tasks-security-lockdown">
 			<?php \esc_html_e( 'A critical WordPress security update is available. Install it as soon as possible — other recommendations will return once your site is secure.', 'progress-planner' ); ?>
 		</p>

--- a/views/page-widgets/suggested-tasks.php
+++ b/views/page-widgets/suggested-tasks.php
@@ -23,15 +23,21 @@ if ( ! \defined( 'ABSPATH' ) ) {
 		);
 		?>
 	</h2>
-	<p class="prpl-suggested-tasks-widget-description">
-		<?php
-		\printf(
-			/* translators: %s: Ravi's name. */
-			\esc_html__( 'Complete a task from %s’s Recommendations to improve your site and earn points toward this month’s badge!', 'progress-planner' ),
-			\esc_html( \progress_planner()->get_ui__branding()->get_ravi_name() )
-		);
-		?>
-	</p>
+	<?php if ( \progress_planner()->get_utils__security_update_monitor()->is_security_lockdown_active() && \current_user_can( 'update_core' ) ) : ?>
+		<p class="prpl-suggested-tasks-widget-description prpl-suggested-tasks-security-lockdown">
+			<?php \esc_html_e( 'A critical WordPress security update is available. Install it as soon as possible — other recommendations will return once your site is secure.', 'progress-planner' ); ?>
+		</p>
+	<?php else : ?>
+		<p class="prpl-suggested-tasks-widget-description">
+			<?php
+			\printf(
+				/* translators: %s: Ravi's name. */
+				\esc_html__( 'Complete a task from %s’s Recommendations to improve your site and earn points toward this month’s badge!', 'progress-planner' ),
+				\esc_html( \progress_planner()->get_ui__branding()->get_ravi_name() )
+			);
+			?>
+		</p>
+	<?php endif; ?>
 
 	<ul style="display:none"></ul>
 	<ul id="prpl-suggested-tasks-list" class="prpl-suggested-tasks-list"></ul>


### PR DESCRIPTION
## What

When a WordPress core **security release** is available, put site owners on highest alert:

- A new `security-update` task (priority 0, 2 points, **not dismissable, not snoozable**) becomes the **only recommendation shown** to users who can install it — including under "Show all recommendations" — until the update is installed.
- The task carries a **one-click, branch-pinned update button** ("Update to WordPress 6.9.7 now"): a form POSTing the exact offered version + locale to core's own `update-core.php?action=do-core-upgrade` handler. This matters because the wp-admin Updates page never shows same-branch patches (`get_core_updates()` skips `autoupdate` offers) and would push a branch-behind user toward the next major instead. `find_core_update()` accepts any offer in the transient, so core's native upgrade flow (nonce, capability, maintenance mode, FS credentials) runs pinned to the branch patch. A "Go to the Updates page" link remains as fallback.
- All administrators (`update_core` users) receive a direct `wp_mail` alert, once per offered version. No email addresses leave the site, and the alert path makes **zero outbound HTTP requests** (covered by a regression test).
- The `get-stats` payload gains a `security_updates` block (`pending`, `installed_version`, `offered_version`, `last_alerted_version`) so progressplanner.com can email the registered subscriber via the **feed-driven approach** (see below).

## The alert email

Sent as plain text, one individually addressed `wp_mail` per recipient, translatable via the `progress-planner` textdomain. For an **onboarded** site (example: 6.9.1 offered 6.9.7):

> **Subject:** [Example Site] Critical: WordPress 6.9.7 security update available
>
> A WordPress security release is available: version 6.9.7 (your site runs 6.9.1).
>
> Security issues in WordPress are typically exploited within hours of a release, so please update as soon as possible:
>
> https://example.org/wp-admin/admin.php?page=progress-planner
>
> Your Progress Planner dashboard has a one-click button to install exactly this update; the task will be marked complete once your site is updated.
>
> If you have a backup solution, make a fresh backup before updating — but do not postpone the update if you have none. Learn more about backups: https://wordpress.org/documentation/article/wordpress-backups/
>
> If your site has automatic updates enabled, it may install this update by itself — in that case, please verify that the update has been applied.
>
> This alert was sent by the Progress Planner plugin.

Sites that have **not onboarded** get the same email without the dashboard paragraph, with the link pointing to `wp-admin/update-core.php` instead (their PP dashboard would show the welcome screen, not the task).

## Detection

Every **patch release on the installed branch** (e.g. 6.8.1 → 6.8.2) is treated as a security release. Cross-branch jumps (6.7.2 → 6.8.0) and alpha/beta/RC builds never trigger. Branch-behind sites are covered because WordPress serves a same-branch point-release offer whenever security fixes ship — note that once a newer major exists, that offer arrives with response `autoupdate` (only the newest release is labeled `upgrade`), so detection accepts both response types. Verified against the live version-check API for a 6.9.1 site (`upgrade 7.0.4` / `autoupdate 7.0.4` / `autoupdate 6.9.7` → detects 6.9.7).

Detection hooks `set_site_transient_update_core`, so it fires from front-end cron — no admin visit needed — with an `admin_init` fallback.

## Lifecycle

- Task IDs are versioned (`security-update-6-8-2`): each release is a fresh task with fresh points, even after an older one was completed.
- Superseded or withdrawn offers are cleaned up silently (no bogus celebration).
- Installing the update manually completes the task with the normal celebration; auto-updates complete it silently via `automatic_updates_complete`.

## Deliberately not locked down

- Users without `update_core` (they can't act on it) keep their normal task list.
- The user's own to-do list (`user` provider).
- Pending-celebration and other non-publish statuses, so celebrations still fire during lockdown.
- The SaaS-facing `/progress-planner/v1/tasks` endpoint.

## Also in this PR

- `rest_prepare_recommendation()` hardened against an undefined `prpl_url` meta index (exposed by the new tests when meta isn't registered).
- `on_automatic_updates_complete()` generalized to handle both `update-core` and `security-update` tasks.

## SaaS-side work (separate, on progressplanner.com): feed-driven subscriber email

No new endpoint. Instead, progressplanner.com watches the wordpress.org releases feed; when a patch release ships for branch X.Y, it polls connected sites' existing `get-stats` endpoint and emails the subscriber of any site whose `security_updates.installed_version` is on branch X.Y below the new patch. Notes:

- Decide from `installed_version` + the feed, **not** the site's `pending` flag — a freshly polled site's own update check may not have run yet. `installed_version` reads the running version and is always accurate.
- Dedupe per (site, offered version) server-side.
- Queue/spread the release-day polling burst.

An earlier revision of this PR pushed a `security-update-alert` ping to the SaaS; it was removed (see commit history) because a push-triggers-email endpoint is an abuse surface the feed-driven design avoids entirely.

## Testing

- 33 new PHPUnit tests (detection matrix, alert throttling/recipients/no-outbound-HTTP, provider lifecycle incl. superseded/withdrawn offers, lockdown on both REST chokepoints, System_Status). Full suite: 432 tests / 1269 assertions green.
- PHPStan level 10, WPCS, and PHP lint all clean.
- Not yet covered: a Playwright spec (would fake the offer via `pre_site_transient_update_core` and assert the single-card lockdown) and manual verification on a live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


