### PR TITLE
Bump squizlabs/php_codesniffer to 3.13.6 (CVE-2026-67434)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5234,16 +5234,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -5309,7 +5309,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/console",


### PR DESCRIPTION
## What

Bumps the dev dependency `squizlabs/php_codesniffer` 3.13.5 → 3.13.6 in `composer.lock`.

## Why

3.13.5 has a known OS command injection vulnerability ([CVE-2026-67434 / GHSA-hmqg-cxww-wqhq](https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq)), which currently makes the **Security** workflow fail on every PR (first seen on #769, but it fails regardless of branch).

Same spirit as #768 (WPCS 3.4.1 security bump).

## Verification

- `composer check-cs` passes on 3.13.6 (clean run against develop).
- Lock-only change; no constraint changes in composer.json needed.

## Note for the team

The `test` (Plugin Check) workflow also fails repo-wide right now for a separate reason: `readme.txt` says `Tested up to: 6.9` while WordPress 7.0 is current (`outdated_tested_upto_header` error). Bumping that is a product statement, so it's deliberately not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)