### PR TITLE
Bump "Tested up to" to WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: joostdevalk, aristath, filipi, jonoaldersonwp, mariekerakt, irisguelen, samalderson, tacoverdo
 Tags: planning, maintenance, writing, blogging
 Requires at least: 6.7
-Tested up to: 6.9
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 1.9.1
 License: GPL3+


### PR DESCRIPTION
## What

`readme.txt`: `Tested up to: 6.9` → `7.1`.

## Why

The Plugin Check workflow (`test` job) currently fails on **every** PR with `outdated_tested_upto_header` ("Tested up to: 6.9 < 7.1") since WordPress 7.1 shipped — first noticed on #769, but unrelated to any PR's changes.

CI already exercises WP latest (7.1): all integration jobs (PHP 8.2/8.3/8.4, single + multisite) and the Playwright e2e suite pass on it, so the declaration matches what is actually tested.

## Note

`Requires at least` is consistent on `develop` (`6.7` in both `readme.txt` and the plugin header, aligned in 6e0edec8 / 8c0fd013, Dec 2025, and matching the CI floor of WP 6.7). `main` (1.9.1) still carries the older `6.3` (readme) / `6.6` (header) pair — those alignment commits never reached it; the next release from `develop` fixes that automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
