### PR TITLE
Harden interactive task handlers

### DIFF
--- a/assets/js/recommendations/core-siteicon.js
+++ b/assets/js/recommendations/core-siteicon.js
@@ -159,12 +159,16 @@
 					? attachment.sizes.thumbnail.url
 					: attachment.url;
 
-			this.elements.preview.innerHTML =
-				'<img src="' +
-				imageUrl +
-				'" alt="' +
-				( attachment.alt || 'Site icon preview' ) +
-				'" style="max-width: 150px; height: auto; border-radius: 4px; border: 1px solid #ddd;">';
+			// Build the node instead of interpolating into an HTML string: the
+			// alt text is free-text set by any upload-capable user, and a value
+			// like `" onerror="` would otherwise break out of the attribute.
+			const img = document.createElement( 'img' );
+			img.src = imageUrl;
+			img.alt = attachment.alt || 'Site icon preview';
+			img.style.cssText =
+				'max-width: 150px; height: auto; border-radius: 4px; border: 1px solid #ddd;';
+
+			this.elements.preview.replaceChildren( img );
 		}
 
 		/**

--- a/assets/js/recommendations/yoast-organization-logo.js
+++ b/assets/js/recommendations/yoast-organization-logo.js
@@ -164,12 +164,16 @@
 					? attachment.sizes.thumbnail.url
 					: attachment.url;
 
-			this.elements.preview.innerHTML =
-				'<img src="' +
-				imageUrl +
-				'" alt="' +
-				( attachment.alt || 'Site icon preview' ) +
-				'" style="max-width: 150px; height: auto; border-radius: 4px; border: 1px solid #ddd;">';
+			// Build the node instead of interpolating into an HTML string: the
+			// alt text is free-text set by any upload-capable user, and a value
+			// like `" onerror="` would otherwise break out of the attribute.
+			const img = document.createElement( 'img' );
+			img.src = imageUrl;
+			img.alt = attachment.alt || 'Site icon preview';
+			img.style.cssText =
+				'max-width: 150px; height: auto; border-radius: 4px; border: 1px solid #ddd;';
+
+			this.elements.preview.replaceChildren( img );
 		}
 
 		/**

--- a/classes/suggested-tasks/providers/class-email-sending.php
+++ b/classes/suggested-tasks/providers/class-email-sending.php
@@ -189,6 +189,12 @@ class Email_Sending extends Tasks_Interactive {
 	 * @return void
 	 */
 	public function enqueue_scripts( $hook ) {
+		// Don't enqueue the script if the user lacks the capability required by this task,
+		// since the localized data contains a nonce.
+		if ( ! $this->capability_required() ) {
+			return;
+		}
+
 		// Enqueue the script only on Progress Planner and WP dashboard pages.
 		if ( 'toplevel_page_progress-planner' !== $hook && 'index.php' !== $hook ) {
 			return;

--- a/classes/suggested-tasks/providers/class-hello-world.php
+++ b/classes/suggested-tasks/providers/class-hello-world.php
@@ -115,7 +115,7 @@ class Hello_World extends Tasks_Interactive {
 		$content .= \sprintf(
 			/* translators: %s: Link to the post. */
 			\esc_html__( 'On install, WordPress creates a "Hello World!" post. You can find yours at %s.', 'progress-planner' ),
-			'<a href="' . \esc_attr( $hello_world_post_url ) . '" target="_self">' . \esc_html( $hello_world_post_url ) . '</a>',
+			'<a href="' . \esc_url( $hello_world_post_url ) . '" target="_self">' . \esc_html( $hello_world_post_url ) . '</a>',
 		);
 		$content .= '</p><p>';
 		$content .= \esc_html__( 'This post does not add value to your website and solely exists to show what a post can look like. Therefore, "Hello World!" is not needed and should be deleted.', 'progress-planner' );

--- a/classes/suggested-tasks/providers/class-remove-terms-without-posts.php
+++ b/classes/suggested-tasks/providers/class-remove-terms-without-posts.php
@@ -453,6 +453,25 @@ class Remove_Terms_Without_Posts extends Tasks_Interactive {
 			\wp_send_json_error( [ 'message' => \esc_html__( 'Term not found.', 'progress-planner' ) ] );
 		}
 
+		// Only public taxonomies are tracked by this task, mirroring the check in
+		// maybe_remove_irrelevant_tasks().
+		$taxonomy_object = \get_taxonomy( $taxonomy );
+		if ( ! $taxonomy_object || ! $taxonomy_object->public ) {
+			\wp_send_json_error( [ 'message' => \esc_html__( 'You do not have permission to delete terms.', 'progress-planner' ) ] );
+		}
+
+		// Bind the request to a task that actually suggested this term, so this
+		// handler cannot be repurposed to delete arbitrary terms.
+		if ( ! $this->has_task_for_term( $term_id, $taxonomy ) ) {
+			\wp_send_json_error( [ 'message' => \esc_html__( 'You do not have permission to delete terms.', 'progress-planner' ) ] );
+		}
+
+		// Re-check the post count at deletion time: the term may have gained posts
+		// after the task was created.
+		if ( $term->count > self::MIN_POSTS ) {
+			\wp_send_json_error( [ 'message' => \esc_html__( 'This term is not empty and cannot be deleted.', 'progress-planner' ) ] );
+		}
+
 		// Delete the term.
 		$result = \wp_delete_term( $term_id, $taxonomy );
 
@@ -461,5 +480,25 @@ class Remove_Terms_Without_Posts extends Tasks_Interactive {
 		}
 
 		\wp_send_json_success( [ 'message' => \esc_html__( 'Term deleted successfully.', 'progress-planner' ) ] );
+	}
+
+	/**
+	 * Check whether a task from this provider targets the given term.
+	 *
+	 * @param int    $term_id  The term ID.
+	 * @param string $taxonomy The taxonomy.
+	 *
+	 * @return bool
+	 */
+	protected function has_task_for_term( $term_id, $taxonomy ) {
+		foreach ( \progress_planner()->get_suggested_tasks_db()->get_tasks_by( [ 'provider_id' => $this->get_provider_id() ] ) as $task ) {
+			if ( (int) $task->target_term_id === (int) $term_id
+				&& (string) $task->target_taxonomy === (string) $taxonomy
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/classes/suggested-tasks/providers/class-sample-page.php
+++ b/classes/suggested-tasks/providers/class-sample-page.php
@@ -114,7 +114,7 @@ class Sample_Page extends Tasks_Interactive {
 		$content .= \sprintf(
 			/* translators: %s: Link to the post. */
 			\esc_html__( 'On install, WordPress creates a "Sample Page" page. You can find yours at %s.', 'progress-planner' ),
-			'<a href="' . \esc_attr( $sample_page_url ) . '" target="_blank">' . \esc_html( $sample_page_url ) . '</a>',
+			'<a href="' . \esc_url( $sample_page_url ) . '" target="_blank">' . \esc_html( $sample_page_url ) . '</a>',
 		);
 		$content .= '</p><p>';
 		$content .= \esc_html__( 'This page does not add value to your website and solely exists to show what a page can look like. Therefore, "Sample Page" is not needed and should be deleted.', 'progress-planner' );

--- a/classes/suggested-tasks/providers/class-tasks.php
+++ b/classes/suggested-tasks/providers/class-tasks.php
@@ -736,7 +736,7 @@ abstract class Tasks implements Tasks_Interface {
 		if ( $this->get_external_link_url() ) {
 			$actions[] = [
 				'priority' => 40,
-				'html'     => '<a class="prpl-tooltip-action-text" href="' . \esc_attr( $this->get_external_link_url() ) . '" target="_blank">' . \esc_html__( 'Why is this important?', 'progress-planner' ) . '</a>',
+				'html'     => '<a class="prpl-tooltip-action-text" href="' . \esc_url( $this->get_external_link_url() ) . '" target="_blank">' . \esc_html__( 'Why is this important?', 'progress-planner' ) . '</a>',
 			];
 		} elseif ( isset( $data['content']['rendered'] ) && $data['content']['rendered'] !== '' && ! $this instanceof Tasks_Interactive ) {
 			$actions[] = [

--- a/classes/suggested-tasks/providers/class-update-term-description.php
+++ b/classes/suggested-tasks/providers/class-update-term-description.php
@@ -445,6 +445,18 @@ class Update_Term_Description extends Tasks_Interactive {
 			\wp_send_json_error( [ 'message' => \esc_html__( 'Term not found.', 'progress-planner' ) ] );
 		}
 
+		// Only public taxonomies are tracked by this task.
+		$taxonomy_object = \get_taxonomy( $taxonomy );
+		if ( ! $taxonomy_object || ! $taxonomy_object->public ) {
+			\wp_send_json_error( [ 'message' => \esc_html__( 'You do not have permission to update terms.', 'progress-planner' ) ] );
+		}
+
+		// Bind the request to a task that actually suggested this term, so this
+		// handler cannot be repurposed to edit arbitrary terms.
+		if ( ! $this->has_task_for_term( $term_id, $taxonomy ) ) {
+			\wp_send_json_error( [ 'message' => \esc_html__( 'You do not have permission to update terms.', 'progress-planner' ) ] );
+		}
+
 		// Update the term description.
 		$result = \wp_update_term(
 			$term_id,
@@ -459,5 +471,25 @@ class Update_Term_Description extends Tasks_Interactive {
 		}
 
 		\wp_send_json_success( [ 'message' => \esc_html__( 'Term description updated successfully.', 'progress-planner' ) ] );
+	}
+
+	/**
+	 * Check whether a task from this provider targets the given term.
+	 *
+	 * @param int    $term_id  The term ID.
+	 * @param string $taxonomy The taxonomy.
+	 *
+	 * @return bool
+	 */
+	protected function has_task_for_term( $term_id, $taxonomy ) {
+		foreach ( \progress_planner()->get_suggested_tasks_db()->get_tasks_by( [ 'provider_id' => $this->get_provider_id() ] ) as $task ) {
+			if ( (int) $task->target_term_id === (int) $term_id
+				&& (string) $task->target_taxonomy === (string) $taxonomy
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-archive-author.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-archive-author.php
@@ -153,8 +153,7 @@ class Archive_Author extends AIOSEO_Interactive_Provider {
 	 * @return void
 	 */
 	public function handle_interactive_task_specific_submit() {
-		$this->verify_aioseo_active_or_fail();
-		$this->verify_nonce_or_fail();
+		$this->verify_aioseo_ajax_security();
 
 		\aioseo()->options->searchAppearance->archives->author->show = false; // @phpstan-ignore-line
 

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-archive-date.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-archive-date.php
@@ -140,8 +140,7 @@ class Archive_Date extends AIOSEO_Interactive_Provider {
 	 * @return void
 	 */
 	public function handle_interactive_task_specific_submit() {
-		$this->verify_aioseo_active_or_fail();
-		$this->verify_nonce_or_fail();
+		$this->verify_aioseo_ajax_security();
 
 		\aioseo()->options->searchAppearance->archives->date->show = false; // @phpstan-ignore-line
 

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-authors.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-authors.php
@@ -150,8 +150,7 @@ class Crawl_Settings_Feed_Authors extends AIOSEO_Interactive_Provider {
 	 * @return void
 	 */
 	public function handle_interactive_task_specific_submit() {
-		$this->verify_aioseo_active_or_fail();
-		$this->verify_nonce_or_fail();
+		$this->verify_aioseo_ajax_security();
 
 		\aioseo()->options->searchAppearance->advanced->crawlCleanup->feeds->authors = false; // @phpstan-ignore-line
 

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-comments.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-crawl-settings-feed-comments.php
@@ -119,8 +119,7 @@ class Crawl_Settings_Feed_Comments extends AIOSEO_Interactive_Provider {
 	 * @return void
 	 */
 	public function handle_interactive_task_specific_submit() {
-		$this->verify_aioseo_active_or_fail();
-		$this->verify_nonce_or_fail();
+		$this->verify_aioseo_ajax_security();
 
 		// Global comment feed.
 		if ( \aioseo()->options->searchAppearance->advanced->crawlCleanup->feeds->globalComments ) { // @phpstan-ignore-line

--- a/classes/suggested-tasks/providers/integrations/aioseo/class-media-pages.php
+++ b/classes/suggested-tasks/providers/integrations/aioseo/class-media-pages.php
@@ -126,8 +126,7 @@ class Media_Pages extends AIOSEO_Interactive_Provider {
 	 * @return void
 	 */
 	public function handle_interactive_task_specific_submit() {
-		$this->verify_aioseo_active_or_fail();
-		$this->verify_nonce_or_fail();
+		$this->verify_aioseo_ajax_security();
 
 		\aioseo()->dynamicOptions->searchAppearance->postTypes->attachment->redirectAttachmentUrls = 'attachment'; // @phpstan-ignore-line
 

--- a/tests/phpunit/test-class-term-task-binding.php
+++ b/tests/phpunit/test-class-term-task-binding.php
@@ -218,13 +218,16 @@ class Term_Task_Binding_Test extends \WP_Ajax_UnitTestCase {
 	/**
 	 * A suggested term that has since gained posts is not deleted.
 	 *
+	 * This exercises the post-count re-check specifically, so the posts are
+	 * attached *before* the task row is written. Creating the task first would
+	 * mean no matching task exists by the time the handler runs, and the request
+	 * would be stopped by the binding check without ever reaching the count
+	 * re-check this test is for.
+	 *
 	 * @return void
 	 */
 	public function test_delete_rejects_suggested_term_that_gained_posts() {
 		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
-
-		$provider = new Remove_Terms_Without_Posts();
-		$this->create_task_for_term( $provider, $term_id, 'category' );
 
 		// Give the term enough posts to exceed MIN_POSTS.
 		foreach ( [ 1, 2 ] as $ignored ) {
@@ -232,10 +235,19 @@ class Term_Task_Binding_Test extends \WP_Ajax_UnitTestCase {
 			\wp_set_object_terms( $post_id, [ $term_id ], 'category', true );
 		}
 
+		// Then record the task, mirroring a task created before the posts landed.
+		$provider = new Remove_Terms_Without_Posts();
+		$this->create_task_for_term( $provider, $term_id, 'category' );
+
 		$this->set_request( $term_id, 'category' );
 		$response = $this->get_response( $provider );
 
 		$this->assertFalse( $response['success'], 'A term with posts should not be deleted.' );
+		$this->assertSame(
+			'This term is not empty and cannot be deleted.',
+			$response['data']['message'],
+			'The rejection should come from the post-count re-check, not another guard.'
+		);
 		$this->assertFalse( \is_wp_error( \get_term( $term_id, 'category' ) ), 'Term should not have been deleted.' );
 	}
 }

--- a/tests/phpunit/test-class-term-task-binding.php
+++ b/tests/phpunit/test-class-term-task-binding.php
@@ -58,7 +58,7 @@ class Term_Task_Binding_Test extends \WP_Ajax_UnitTestCase {
 		}
 
 		// The handlers read from $_POST; check_ajax_referer reads $_REQUEST.
-		$_POST = $_REQUEST;
+		$_POST = $_REQUEST; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce verified via check_ajax_referer in the handlers.
 	}
 
 	/**

--- a/tests/phpunit/test-class-term-task-binding.php
+++ b/tests/phpunit/test-class-term-task-binding.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Tests for term task request binding.
+ *
+ * The term interactive tasks act on a term_id/taxonomy pair taken from the
+ * request. These tests cover that the handlers only act on terms that a task
+ * from the same provider actually suggested, so they cannot be repurposed to
+ * delete or edit arbitrary terms.
+ *
+ * @package Progress_Planner\Tests
+ */
+
+namespace Progress_Planner\Tests;
+
+use Progress_Planner\Suggested_Tasks\Providers\Remove_Terms_Without_Posts;
+use Progress_Planner\Suggested_Tasks\Providers\Update_Term_Description;
+
+/**
+ * Term task binding test case.
+ */
+class Term_Task_Binding_Test extends \WP_Ajax_UnitTestCase {
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// The term tasks require edit_others_posts (editor level).
+		$this->_setRole( 'editor' );
+	}
+
+	/**
+	 * Clean up.
+	 */
+	public function tear_down() {
+		unset( $_REQUEST['term_id'], $_REQUEST['taxonomy'], $_REQUEST['description'], $_REQUEST['nonce'] );
+		$_POST = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Populate the request with a signed payload.
+	 *
+	 * @param int    $term_id     The term ID.
+	 * @param string $taxonomy    The taxonomy.
+	 * @param string $description Optional description.
+	 *
+	 * @return void
+	 */
+	private function set_request( $term_id, $taxonomy, $description = null ) {
+		$_REQUEST['term_id']  = $term_id;
+		$_REQUEST['taxonomy'] = $taxonomy;
+		$_REQUEST['nonce']    = \wp_create_nonce( 'progress_planner' );
+
+		if ( null !== $description ) {
+			$_REQUEST['description'] = $description;
+		}
+
+		// The handlers read from $_POST; check_ajax_referer reads $_REQUEST.
+		$_POST = $_REQUEST;
+	}
+
+	/**
+	 * Run a handler and return the decoded JSON response.
+	 *
+	 * @param object $provider The task provider.
+	 *
+	 * @return array|null The decoded response.
+	 */
+	private function get_response( $provider ) {
+		// WordPress Core's _handleAjax() starts output buffering before calling
+		// AJAX actions. We do the same since we call the method directly.
+		\ini_set( 'implicit_flush', false ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+		\ob_start();
+
+		try {
+			$provider->handle_interactive_task_submit();
+		} catch ( \WPAjaxDieContinueException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Expected: wp_send_json_* calls wp_die().
+		}
+
+		return \json_decode( $this->_last_response, true );
+	}
+
+	/**
+	 * Create a task from a provider that targets a specific term.
+	 *
+	 * @param object $provider The task provider.
+	 * @param int    $term_id  The term ID.
+	 * @param string $taxonomy The taxonomy.
+	 *
+	 * @return void
+	 */
+	private function create_task_for_term( $provider, $term_id, $taxonomy ) {
+		\progress_planner()->get_suggested_tasks_db()->add(
+			[
+				'post_title'      => 'Term task',
+				'provider_id'     => $provider->get_provider_id(),
+				'target_term_id'  => $term_id,
+				'target_taxonomy' => $taxonomy,
+			]
+		);
+	}
+
+	/**
+	 * An Editor cannot delete an unrelated term that no task suggested.
+	 *
+	 * This is the privilege-escalation case: wp_delete_term() performs no
+	 * capability check of its own, so without binding an Editor could delete
+	 * any term in any taxonomy.
+	 *
+	 * @return void
+	 */
+	public function test_delete_rejects_term_without_matching_task() {
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
+
+		$this->set_request( $term_id, 'category' );
+		$response = $this->get_response( new Remove_Terms_Without_Posts() );
+
+		$this->assertFalse( $response['success'], 'Deletion should be rejected.' );
+
+		$term = \get_term( $term_id, 'category' );
+		$this->assertFalse( \is_wp_error( $term ), 'Term should not have been deleted.' );
+		$this->assertNotNull( $term, 'Term should not have been deleted.' );
+	}
+
+	/**
+	 * An Editor cannot rewrite the description of a term no task suggested.
+	 *
+	 * @return void
+	 */
+	public function test_update_description_rejects_term_without_matching_task() {
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy'    => 'category',
+				'description' => 'Original description.',
+			]
+		);
+
+		$this->set_request( $term_id, 'category', 'Injected description.' );
+		$response = $this->get_response( new Update_Term_Description() );
+
+		$this->assertFalse( $response['success'], 'Update should be rejected.' );
+
+		$term = \get_term( $term_id, 'category' );
+		$this->assertSame( 'Original description.', $term->description, 'Description should be unchanged.' );
+	}
+
+	/**
+	 * A non-public taxonomy is rejected even when a task exists for the term.
+	 *
+	 * @return void
+	 */
+	public function test_delete_rejects_non_public_taxonomy() {
+		\register_taxonomy( 'prpl_private_tax', 'post', [ 'public' => false ] );
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'prpl_private_tax' ] );
+
+		$provider = new Remove_Terms_Without_Posts();
+		$this->create_task_for_term( $provider, $term_id, 'prpl_private_tax' );
+
+		$this->set_request( $term_id, 'prpl_private_tax' );
+		$response = $this->get_response( $provider );
+
+		$this->assertFalse( $response['success'], 'Non-public taxonomy should be rejected.' );
+		$this->assertFalse( \is_wp_error( \get_term( $term_id, 'prpl_private_tax' ) ), 'Term should not have been deleted.' );
+
+		\unregister_taxonomy( 'prpl_private_tax' );
+	}
+
+	/**
+	 * A term that a task legitimately suggested can still be deleted.
+	 *
+	 * Guards against the binding being too strict and breaking the feature.
+	 *
+	 * @return void
+	 */
+	public function test_delete_allows_term_suggested_by_a_task() {
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
+
+		$provider = new Remove_Terms_Without_Posts();
+		$this->create_task_for_term( $provider, $term_id, 'category' );
+
+		$this->set_request( $term_id, 'category' );
+		$response = $this->get_response( $provider );
+
+		$this->assertTrue( $response['success'], 'Deletion of a suggested term should succeed.' );
+
+		$term = \get_term( $term_id, 'category' );
+		$this->assertTrue( null === $term || \is_wp_error( $term ), 'Term should have been deleted.' );
+	}
+
+	/**
+	 * A description update for a legitimately suggested term still works.
+	 *
+	 * @return void
+	 */
+	public function test_update_description_allows_term_suggested_by_a_task() {
+		$term_id = $this->factory->term->create(
+			[
+				'taxonomy'    => 'category',
+				'description' => 'Original description.',
+			]
+		);
+
+		$provider = new Update_Term_Description();
+		$this->create_task_for_term( $provider, $term_id, 'category' );
+
+		$this->set_request( $term_id, 'category', 'A better description.' );
+		$response = $this->get_response( $provider );
+
+		$this->assertTrue( $response['success'], 'Update of a suggested term should succeed.' );
+
+		$term = \get_term( $term_id, 'category' );
+		$this->assertSame( 'A better description.', $term->description, 'Description should have been updated.' );
+	}
+
+	/**
+	 * A suggested term that has since gained posts is not deleted.
+	 *
+	 * @return void
+	 */
+	public function test_delete_rejects_suggested_term_that_gained_posts() {
+		$term_id = $this->factory->term->create( [ 'taxonomy' => 'category' ] );
+
+		$provider = new Remove_Terms_Without_Posts();
+		$this->create_task_for_term( $provider, $term_id, 'category' );
+
+		// Give the term enough posts to exceed MIN_POSTS.
+		foreach ( [ 1, 2 ] as $ignored ) {
+			$post_id = $this->factory->post->create();
+			\wp_set_object_terms( $post_id, [ $term_id ], 'category', true );
+		}
+
+		$this->set_request( $term_id, 'category' );
+		$response = $this->get_response( $provider );
+
+		$this->assertFalse( $response['success'], 'A term with posts should not be deleted.' );
+		$this->assertFalse( \is_wp_error( \get_term( $term_id, 'category' ) ), 'Term should not have been deleted.' );
+	}
+}


### PR DESCRIPTION
Hardening pass across the interactive task handlers, following an external code review of the plugin. Some of the reviewed items were re-scoped after verifying them against the code; the detailed analysis lives in our internal tracker.

## Changes

**Consistent capability checks on AIOSEO interactive tasks**
Five AIOSEO handlers were verifying the plugin was active and the nonce was valid, but not the user's capability. They now call the shared `verify_aioseo_ajax_security()` helper, which covers all three. Every other settings-changing interactive handler already required `manage_options`, so this brings the AIOSEO ones in line with the existing convention rather than introducing a new policy.

**Capability guard on the email-sending task's script enqueue**
`Email_Sending::enqueue_scripts()` overrode its parent without carrying over the parent's capability guard. It now checks `$this->capability_required()` — the provider's own declared capability rather than a hardcoded literal, so it stays correct if a subclass overrides `CAPABILITY`.

**Term task handlers bound to the term the task suggested**
`Remove_Terms_Without_Posts` and `Update_Term_Description` acted on whatever `term_id`/`taxonomy` the request supplied. They now require that a task from the same provider actually targets that term, reject non-public taxonomies, and (for deletion) re-check the post count at submit time.

The constraints already existed when generating the tasks — `maybe_remove_irrelevant_tasks()` skips non-public taxonomies and drops tasks once a term exceeds `MIN_POSTS` — they just weren't applied when acting on the request. The count re-check also closes a genuine race: a term can gain posts between the task being created and the user clicking through.

Binding rather than raising the required capability keeps the feature working for its intended audience. These tasks are meant for Editors, and the JS already submits the task's own `target_term_id`/`target_taxonomy`, so the legitimate flow is unchanged.

**`esc_url()` for hrefs**
Switched `esc_attr()` to `esc_url()` on three links. `esc_url` is the correct escaper for an `href`, since `esc_attr` does not validate the URL scheme.

**Media previews built via DOM instead of HTML strings**
The site icon and Yoast organization logo pickers assembled their preview `<img>` by string concatenation and assigned it to `innerHTML`. They now use `createElement` with property assignment, so attachment metadata is never parsed as markup. Same reasoning as the existing `textContent` usage in `updateTaskTitle()`.

## Testing

`tests/phpunit/test-class-term-task-binding.php` adds 6 tests for the term task binding, covering both the rejected and the permitted paths — the latter so the binding can't silently break the feature.

These were validated by mutation testing — removing each guard in turn and confirming a test fails.

That check initially found a gap in this PR's own tests: `test_delete_rejects_suggested_term_that_gained_posts` created the task row *before* attaching posts to the term, so by the time the handler ran no matching task existed and the request was stopped by the task-binding check, never reaching the post-count re-check the test is named for. Deleting the count guard entirely left all six tests passing. Fixed in 9119eb0d by attaching the posts first and asserting on the specific rejection message, so the test cannot silently drift to a different guard again.

Current state, each guard removed individually:

| Guard removed | Result |
|---|---|
| *baseline* | OK (6 tests, 14 assertions) |
| post-count re-check | 1 failure |
| delete binding | 1 failure |
| update binding | 1 failure |
| public-taxonomy | 2 failures |

The media preview change was verified with jsdom: attachment metadata containing quote characters round-trips as an attribute *value* and never becomes markup.

**Verified:** PHPCS clean · PHPStan clean · JS/CSS lint clean · PHPUnit 404 tests / 1217 assertions passing.

> Note for local runs: PHPStan needs `--memory-limit=2G`; the 512M default OOMs on this codebase, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

