### PR TITLE
Consolidate get_post_types_names() into Settings

### DIFF
--- a/classes/actions/class-content-scan.php
+++ b/classes/actions/class-content-scan.php
@@ -70,7 +70,7 @@ class Content_Scan extends Content {
 			[
 				'posts_per_page' => static::SCAN_POSTS_PER_PAGE,
 				'paged'          => $current_page,
-				'post_type'      => $content_helpers->get_post_types_names(),
+				'post_type'      => \progress_planner()->get_settings()->get_post_types_names(),
 				'post_status'    => 'publish',
 			]
 		);
@@ -102,7 +102,7 @@ class Content_Scan extends Content {
 
 		// Get the total number of posts.
 		$total_posts_count = 0;
-		foreach ( $content_helpers->get_post_types_names() as $post_type ) {
+		foreach ( \progress_planner()->get_settings()->get_post_types_names() as $post_type ) {
 			$total_posts_count += \wp_count_posts( $post_type )->publish;
 		}
 		// Calculate the total pages to scan.

--- a/classes/actions/class-content.php
+++ b/classes/actions/class-content.php
@@ -166,7 +166,7 @@ class Content {
 		// Bail if the post is not included in the post-types we're tracking.
 		if ( ! \in_array(
 			$post->post_type,
-			$content_helpers->get_post_types_names(),
+			\progress_planner()->get_settings()->get_post_types_names(),
 			true
 		) ) {
 			return true;

--- a/classes/activities/class-content-helpers.php
+++ b/classes/activities/class-content-helpers.php
@@ -17,19 +17,12 @@ class Content_Helpers {
 	/**
 	 * Get an array of post-types names for the stats.
 	 *
+	 * @deprecated 1.9.2 Use \progress_planner()->get_settings()->get_post_types_names() instead.
+	 *
 	 * @return string[]
 	 */
 	public function get_post_types_names() {
-		static $include_post_types;
-		if ( isset( $include_post_types ) && ! empty( $include_post_types ) ) {
-			return $include_post_types;
-		}
-		$default            = [ 'post', 'page' ];
-		$include_post_types = \array_filter(
-			\progress_planner()->get_settings()->get( [ 'include_post_types' ], $default ),
-			fn( $post_type ) => $post_type && \post_type_exists( $post_type ) && \is_post_type_viewable( $post_type )
-		);
-		return empty( $include_post_types ) ? $default : \array_values( $include_post_types );
+		return \progress_planner()->get_settings()->get_post_types_names();
 	}
 
 	/**

--- a/classes/admin/widgets/class-content-activity.php
+++ b/classes/admin/widgets/class-content-activity.php
@@ -80,7 +80,7 @@ final class Content_Activity extends Widget {
 			$activities,
 			fn( $activity ) => 'delete' === $activity->type
 				|| ( \is_object( $activity->get_post() )
-					&& \in_array( $activity->get_post()->post_type, \progress_planner()->get_activities__content_helpers()->get_post_types_names(), true )
+					&& \in_array( $activity->get_post()->post_type, \progress_planner()->get_settings()->get_post_types_names(), true )
 				)
 		);
 	}

--- a/classes/badges/content/class-content-curator.php
+++ b/classes/badges/content/class-content-curator.php
@@ -57,7 +57,7 @@ final class Content_Curator extends Badge_Content {
 
 		// Get the total number of posts.
 		$total_posts_count = 0;
-		foreach ( \progress_planner()->get_activities__content_helpers()->get_post_types_names() as $post_type ) {
+		foreach ( \progress_planner()->get_settings()->get_post_types_names() as $post_type ) {
 			$total_posts_count += \wp_count_posts( $post_type )->publish;
 		}
 

--- a/views/page-widgets/content-activity.php
+++ b/views/page-widgets/content-activity.php
@@ -26,7 +26,7 @@ $prpl_activity_types = [
 	],
 ];
 
-$prpl_tracked_post_types = \progress_planner()->get_activities__content_helpers()->get_post_types_names();
+$prpl_tracked_post_types = \progress_planner()->get_settings()->get_post_types_names();
 $prpl_activities_count   = [
 	'all' => 0,
 ];


### PR DESCRIPTION
Implements #433. Replaces #467, which had drifted ~2300 commits behind `develop` and conflicted in 6 of its 7 files.

## The problem

Two copies of `get_post_types_names()` exist in `develop`, and callers were split roughly evenly between them (5 each):

- `classes/class-settings.php:119`
- `classes/activities/class-content-helpers.php:22`

`Settings` has become the canonical one — it's what the newer suggested-task and data-collector classes call, it carries the `init`-timing guard, and it's where the exclusion list has been maintained.

The `Content_Helpers` copy drifted behind. Its filtering logic differs in three ways:

1. **`elementor_library`** — excluded by `Settings`, not by `Content_Helpers`. Elementor registers it as public + viewable, so it passes the `Content_Helpers` viewability check.
2. **The `progress_planner_public_post_types` filter** — only honoured by `Settings`. Anything filtered out there still passes through `Content_Helpers`.
3. **Empty-case fallback** — `Content_Helpers` returns a raw `[ 'post', 'page' ]` without checking those post types are still registered and public; `Settings` intersects against public types first.

Each copy holds its **own** `static` cache, warmed independently on first call. In a normal request both warm after `init` and agree, so the drift is latent rather than actively breaking sites — but it means two functions that are supposed to answer the same question no longer share filtering rules, and any future change to the exclusion list or the filter only lands in one of them.

## The change

- Point the six remaining `Content_Helpers` call sites at `Settings`.
- Reduce `Content_Helpers::get_post_types_names()` to a deprecated one-line shim, so any external caller keeps working.

Net: 9 insertions, 16 deletions across 6 files. One cache and one set of filtering rules instead of two.

### Note on direction

#467 consolidated the *other* way — deleting `Settings::get_post_types_names()` and moving it into `Content_Helpers`. Since that PR was opened, `develop` settled on `Settings` as the home (that's where the `prpl_recommendations` exclusion was added). Rebasing #467 would have meant reverting that decision, which is why this is a fresh change rather than a rebase.

### Note on init ordering

All six migrated call sites run well after `init` — `shutdown`, `wp_insert_post`, and admin widget rendering — so all CPTs are registered by the time they read. The shared cache is warmed by `Tasks_Manager::init()` at `init` priority 99, after the priority 0–10 where CPTs normally register. No call site is moved earlier by this PR.

### Note on the null guards

The `null === $content_helpers` guards in `Content_Scan` and `Content` are deliberately left in place — they still protect the `get_activity_from_post()` calls in those methods. In `Content_Scan::get_total_pages()` the guard no longer covers any `$content_helpers` usage, but it doubles as an intentional circuit-breaker returning `0` to halt the scan during plugin updates (added in #743), so removing it would change update-time behaviour beyond this PR's scope.

## Verification

- `composer check-cs -- --warning-severity=6` — clean (exit 0)
- `composer phpstan` — no errors
- `composer test` — OK (398 tests, 1203 assertions)

Note that the test suite has **no existing coverage** of `get_post_types_names()`, so the suite passing is not by itself evidence for this change. I additionally ran a throwaway differential harness comparing the old `Content_Helpers` implementation against the new delegate across 10 scenarios (public CPT, non-public CPT, `elementor_library`, `attachment`, the `progress_planner_public_post_types` filter, unregistered post types, empty settings) and confirmed both entry points return identical results. That harness was not committed.

The two `wpdberror` lines that appear in the test output are pre-existing; they reproduce identically on unmodified `develop`.
