### PR TITLE
Add sunset notice with downloadable certificate

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -325,6 +325,22 @@ button.prpl-info-icon {
 }
 
 /*------------------------------------*\
+	Sunset notice.
+\*------------------------------------*/
+.prpl-wrap .prpl-sunset-notice {
+	border-left: 4px solid var(--prpl-background-banner);
+
+	h1 {
+		color: var(--prpl-color-headings);
+		margin-top: 0;
+	}
+
+	p {
+		max-width: 680px;
+	}
+}
+
+/*------------------------------------*\
   Buttons
 \*------------------------------------*/
 

--- a/classes/admin/class-sunset-notice.php
+++ b/classes/admin/class-sunset-notice.php
@@ -17,13 +17,6 @@ namespace Progress_Planner\Admin;
 class Sunset_Notice {
 
 	/**
-	 * The URL with more information about the end of support.
-	 *
-	 * @var string
-	 */
-	const LEARN_MORE_URL = 'https://prpl.fyi/sunset';
-
-	/**
 	 * The admin-post action for the certificate page.
 	 *
 	 * @var string
@@ -72,17 +65,10 @@ class Sunset_Notice {
 	/**
 	 * Get the notice message, shared by both surfaces.
 	 *
-	 * Contains an anchor tag, so it should be escaped with `wp_kses_post` on output.
-	 *
 	 * @return string
 	 */
 	public function get_message() {
-		return \sprintf(
-			/* translators: %1$s: opening <a> tag, %2$s: closing </a> tag. */
-			\esc_html__( 'Support and updates for the free Progress Planner plugin are ending. We are incredibly grateful for your support over the years — thank you for improving your website with us! %1$sLearn more about what this means for your site%2$s.', 'progress-planner' ),
-			'<a href="' . \esc_url( self::LEARN_MORE_URL ) . '" target="_blank" rel="noopener">',
-			'</a>'
-		);
+		return \esc_html__( 'Support and updates for the free Progress Planner plugin are ending. We are incredibly grateful for your support over the years — thank you for improving your website with us!', 'progress-planner' );
 	}
 
 	/**

--- a/classes/admin/class-sunset-notice.php
+++ b/classes/admin/class-sunset-notice.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Sunset notice class.
+ *
+ * Displays a notice that support for the plugin is ending, on the
+ * Progress Planner dashboard and on the plugins overview page.
+ * The notice is hidden when the pp-hosts companion plugin is present.
+ *
+ * @package Progress_Planner
+ */
+
+namespace Progress_Planner\Admin;
+
+/**
+ * Sunset notice class.
+ */
+class Sunset_Notice {
+
+	/**
+	 * The URL with more information about the end of support.
+	 *
+	 * @var string
+	 */
+	const LEARN_MORE_URL = 'https://prpl.fyi/sunset';
+
+	/**
+	 * The admin-post action for the certificate page.
+	 *
+	 * @var string
+	 */
+	const CERTIFICATE_ACTION = 'prpl_sunset_certificate';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( ! $this->should_show() ) {
+			return;
+		}
+
+		\add_action( 'progress_planner_admin_page_header_before', [ $this, 'the_dashboard_notice' ] );
+		\add_action( 'after_plugin_row_' . \plugin_basename( \PROGRESS_PLANNER_FILE ), [ $this, 'the_plugin_row_notice' ] );
+		\add_action( 'admin_post_' . self::CERTIFICATE_ACTION, [ $this, 'render_certificate' ] );
+	}
+
+	/**
+	 * Whether the sunset notice should be shown.
+	 *
+	 * The notice only applies to installs coming from wordpress.org or FAIR.
+	 * It is hidden when the pp-hosts companion plugin is active (constants or
+	 * class detection), when a host defines a branding ID, or when pp-hosts
+	 * is installed but not (yet) activated.
+	 *
+	 * @return bool
+	 */
+	public function should_show() {
+		$show = ! (
+			\defined( 'PP_HOSTS_FILE' )
+			|| \defined( 'PROGRESS_PLANNER_BRANDING_ID' )
+			|| \class_exists( 'PP_Hosts\Updater' )
+			|| \progress_planner()->get_plugin_installer()->is_plugin_installed( 'pp-hosts' )
+		);
+
+		/**
+		 * Filter whether the sunset notice should be shown.
+		 *
+		 * @param bool $show Whether the notice should be shown.
+		 */
+		return (bool) \apply_filters( 'progress_planner_show_sunset_notice', $show );
+	}
+
+	/**
+	 * Get the notice message, shared by both surfaces.
+	 *
+	 * Contains an anchor tag, so it should be escaped with `wp_kses_post` on output.
+	 *
+	 * @return string
+	 */
+	public function get_message() {
+		return \sprintf(
+			/* translators: %1$s: opening <a> tag, %2$s: closing </a> tag. */
+			\esc_html__( 'Support and updates for the free Progress Planner plugin are ending. We are incredibly grateful for your support over the years — thank you for improving your website with us! %1$sLearn more about what this means for your site%2$s.', 'progress-planner' ),
+			'<a href="' . \esc_url( self::LEARN_MORE_URL ) . '" target="_blank" rel="noopener">',
+			'</a>'
+		);
+	}
+
+	/**
+	 * Get the certificate invitation sentence.
+	 *
+	 * Contains an anchor tag, so it should be escaped with `wp_kses_post` on output.
+	 *
+	 * @return string
+	 */
+	public function get_certificate_message() {
+		return \sprintf(
+			/* translators: %1$s: opening <a> tag, %2$s: closing </a> tag. */
+			\esc_html__( 'As a keepsake, you can %1$sdownload a certificate%2$s with your site\'s achievements.', 'progress-planner' ),
+			'<a href="' . \esc_url( $this->get_certificate_url() ) . '" target="_blank" rel="noopener">',
+			'</a>'
+		);
+	}
+
+	/**
+	 * Get the URL of the certificate page.
+	 *
+	 * @return string
+	 */
+	public function get_certificate_url() {
+		return \admin_url( 'admin-post.php?action=' . self::CERTIFICATE_ACTION );
+	}
+
+	/**
+	 * Get all completed badges, across all badge contexts.
+	 *
+	 * @return \Progress_Planner\Badges\Badge[]
+	 */
+	public function get_completed_badges() {
+		$completed = [];
+		foreach ( [ 'content', 'maintenance', 'monthly_flat' ] as $context ) {
+			foreach ( \progress_planner()->get_badges()->get_badges( $context ) as $badge ) {
+				$progress = $badge->get_progress();
+				if ( isset( $progress['progress'] ) && 100 === (int) $progress['progress'] ) {
+					$completed[] = $badge;
+				}
+			}
+		}
+		return $completed;
+	}
+
+	/**
+	 * Render the standalone certificate page and exit.
+	 *
+	 * Hooked to admin-post, so this renders outside the WP admin chrome.
+	 *
+	 * @return void
+	 */
+	public function render_certificate() {
+		if ( ! \current_user_can( 'edit_others_posts' ) ) {
+			\wp_die( \esc_html__( 'You do not have permission to view this page.', 'progress-planner' ) );
+		}
+		$this->the_certificate();
+		exit;
+	}
+
+	/**
+	 * Print the certificate page markup.
+	 *
+	 * @return void
+	 */
+	public function the_certificate() {
+		\progress_planner()->the_view( 'sunset-certificate.php' );
+	}
+
+	/**
+	 * Print the notice banner on the Progress Planner dashboard.
+	 *
+	 * @return void
+	 */
+	public function the_dashboard_notice() {
+		\progress_planner()->the_view( 'sunset-notice.php' );
+	}
+
+	/**
+	 * Print a notice row below the plugin's row on the plugins overview page.
+	 *
+	 * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+	 *
+	 * @return void
+	 */
+	public function the_plugin_row_notice( $plugin_file ) {
+		if ( ! \current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		$prpl_colspan = 4;
+		if ( \function_exists( '_get_list_table' ) ) {
+			$prpl_colspan = \_get_list_table( 'WP_Plugins_List_Table', [ 'screen' => 'plugins' ] )->get_column_count();
+		}
+
+		$prpl_is_active = \function_exists( 'is_plugin_active' ) && \is_plugin_active( $plugin_file );
+		?>
+		<tr class="plugin-update-tr <?php echo \esc_attr( $prpl_is_active ? 'active' : 'inactive' ); ?>" id="prpl-sunset-notice-row" data-slug="progress-planner" data-plugin="<?php echo \esc_attr( $plugin_file ); ?>">
+			<td colspan="<?php echo (int) $prpl_colspan; ?>" class="plugin-update colspanchange">
+				<div class="update-message notice inline notice-warning notice-alt">
+					<p><?php echo \wp_kses_post( $this->get_message() . ' ' . $this->get_certificate_message() ); ?></p>
+				</div>
+			</td>
+		</tr>
+		<?php
+	}
+}

--- a/classes/admin/class-sunset-notice.php
+++ b/classes/admin/class-sunset-notice.php
@@ -168,11 +168,24 @@ class Sunset_Notice {
 		?>
 		<tr class="plugin-update-tr <?php echo \esc_attr( $prpl_is_active ? 'active' : 'inactive' ); ?>" id="prpl-sunset-notice-row" data-slug="progress-planner" data-plugin="<?php echo \esc_attr( $plugin_file ); ?>">
 			<td colspan="<?php echo (int) $prpl_colspan; ?>" class="plugin-update colspanchange">
-				<div class="update-message notice inline notice-warning notice-alt">
+				<div class="notice inline notice-warning notice-alt prpl-sunset-row-notice">
 					<p><?php echo \wp_kses_post( $this->get_message() . ' ' . $this->get_certificate_message() ); ?></p>
 				</div>
 			</td>
 		</tr>
+		<style>
+			/* Opt out of core's red "update available" dashicon, which this notice is not. */
+			#prpl-sunset-notice-row .prpl-sunset-row-notice p:before {
+				content: "\f534";
+				display: inline-block;
+				font: normal 20px/1 dashicons;
+				color: #b26200;
+				margin: -3px 5px 0 -2px;
+				vertical-align: middle;
+				-webkit-font-smoothing: antialiased;
+				-moz-osx-font-smoothing: grayscale;
+			}
+		</style>
 		<?php
 	}
 }

--- a/classes/admin/class-sunset-notice.php
+++ b/classes/admin/class-sunset-notice.php
@@ -68,7 +68,7 @@ class Sunset_Notice {
 	 * @return string
 	 */
 	public function get_message() {
-		return \esc_html__( 'Support and updates for the free Progress Planner plugin are ending. We are incredibly grateful for your support over the years — thank you for improving your website with us!', 'progress-planner' );
+		return \esc_html__( 'Support and updates for the free Progress Planner plugin have ended. We are incredibly grateful for your support over the years — thank you for improving your website with us!', 'progress-planner' );
 	}
 
 	/**

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -110,6 +110,7 @@ class Base {
 		if ( \is_admin() && \current_user_can( 'edit_others_posts' ) ) {
 			$this->get_admin__page();
 			$this->get_admin__tour();
+			$this->get_admin__sunset_notice();
 
 			// Dont add the widget if the privacy policy is not accepted.
 			if ( true === $this->is_privacy_policy_accepted() ) {

--- a/tests/phpunit/test-class-sunset-notice.php
+++ b/tests/phpunit/test-class-sunset-notice.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Class Sunset_Notice_Test
+ *
+ * @package Progress_Planner\Tests
+ */
+
+namespace Progress_Planner\Tests;
+
+use Progress_Planner\Admin\Sunset_Notice;
+
+/**
+ * Sunset notice test case.
+ */
+class Sunset_Notice_Test extends \WP_UnitTestCase {
+
+	/**
+	 * Clean up after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		\remove_all_filters( 'progress_planner_show_sunset_notice' );
+		\remove_all_actions( 'progress_planner_admin_page_header_before' );
+		\remove_all_actions( 'after_plugin_row_' . \plugin_basename( \PROGRESS_PLANNER_FILE ) );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that should_show returns true in a clean install.
+	 *
+	 * @return void
+	 */
+	public function test_should_show_by_default() {
+		$notice = new Sunset_Notice();
+		$this->assertTrue( $notice->should_show() );
+	}
+
+	/**
+	 * Test that hooks are registered on instantiation in a clean install.
+	 *
+	 * @return void
+	 */
+	public function test_hooks_registered_by_default() {
+		$notice = new Sunset_Notice();
+		$this->assertNotFalse( \has_action( 'progress_planner_admin_page_header_before', [ $notice, 'the_dashboard_notice' ] ) );
+		$this->assertNotFalse( \has_action( 'after_plugin_row_' . \plugin_basename( \PROGRESS_PLANNER_FILE ), [ $notice, 'the_plugin_row_notice' ] ) );
+	}
+
+	/**
+	 * Test that hooks are not registered when the filter hides the notice.
+	 *
+	 * @return void
+	 */
+	public function test_hooks_not_registered_when_filtered_out() {
+		\add_filter( 'progress_planner_show_sunset_notice', '__return_false' );
+		$notice = new Sunset_Notice();
+		$this->assertFalse( $notice->should_show() );
+		$this->assertFalse( \has_action( 'progress_planner_admin_page_header_before', [ $notice, 'the_dashboard_notice' ] ) );
+		$this->assertFalse( \has_action( 'after_plugin_row_' . \plugin_basename( \PROGRESS_PLANNER_FILE ), [ $notice, 'the_plugin_row_notice' ] ) );
+	}
+
+	/**
+	 * Test that the message contains the learn-more link.
+	 *
+	 * @return void
+	 */
+	public function test_message_contains_learn_more_link() {
+		$notice = new Sunset_Notice();
+		$this->assertStringContainsString( Sunset_Notice::LEARN_MORE_URL, $notice->get_message() );
+	}
+
+	/**
+	 * Test the plugin-row notice output.
+	 *
+	 * @return void
+	 */
+	public function test_plugin_row_notice_output() {
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		if ( \is_multisite() ) {
+			\grant_super_admin( $user_id );
+		}
+		\wp_set_current_user( $user_id );
+
+		$notice = new Sunset_Notice();
+		\ob_start();
+		$notice->the_plugin_row_notice( \plugin_basename( \PROGRESS_PLANNER_FILE ), [] );
+		$output = \ob_get_clean();
+
+		$this->assertStringContainsString( 'plugin-update-tr', $output );
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringContainsString( Sunset_Notice::LEARN_MORE_URL, $output );
+	}
+
+	/**
+	 * Test that the certificate endpoint is registered on instantiation.
+	 *
+	 * @return void
+	 */
+	public function test_certificate_endpoint_registered() {
+		$notice = new Sunset_Notice();
+		$this->assertNotFalse( \has_action( 'admin_post_' . Sunset_Notice::CERTIFICATE_ACTION, [ $notice, 'render_certificate' ] ) );
+	}
+
+	/**
+	 * Test that get_completed_badges only returns badges with 100% progress.
+	 *
+	 * @return void
+	 */
+	public function test_get_completed_badges_are_complete() {
+		$notice = new Sunset_Notice();
+		$badges = $notice->get_completed_badges();
+		$this->assertIsArray( $badges );
+		foreach ( $badges as $badge ) {
+			$this->assertInstanceOf( \Progress_Planner\Badges\Badge::class, $badge );
+			$this->assertSame( 100, (int) $badge->get_progress()['progress'] );
+		}
+	}
+
+	/**
+	 * Test the certificate output contains the site URL and activation year.
+	 *
+	 * @return void
+	 */
+	public function test_certificate_output() {
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		\wp_set_current_user( $user_id );
+
+		$notice = new Sunset_Notice();
+		\ob_start();
+		$notice->the_certificate();
+		$output = \ob_get_clean();
+
+		$this->assertStringContainsString( \home_url(), $output );
+		$this->assertStringContainsString( \progress_planner()->get_activation_date()->format( 'Y' ), $output );
+		$this->assertStringContainsString( 'prpl-certificate', $output );
+	}
+
+	/**
+	 * Test that the certificate endpoint dies for users without capabilities.
+	 *
+	 * @return void
+	 */
+	public function test_certificate_requires_capability() {
+		\wp_set_current_user( 0 );
+
+		$notice = new Sunset_Notice();
+		$this->expectException( \WPDieException::class );
+		$notice->render_certificate();
+	}
+
+	/**
+	 * Test that the plugin-row notice outputs nothing for users without capabilities.
+	 *
+	 * @return void
+	 */
+	public function test_plugin_row_notice_requires_capability() {
+		\wp_set_current_user( 0 );
+
+		$notice = new Sunset_Notice();
+		\ob_start();
+		$notice->the_plugin_row_notice( \plugin_basename( \PROGRESS_PLANNER_FILE ), [] );
+		$output = \ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+}

--- a/tests/phpunit/test-class-sunset-notice.php
+++ b/tests/phpunit/test-class-sunset-notice.php
@@ -61,13 +61,14 @@ class Sunset_Notice_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the message contains the learn-more link.
+	 * Test that the message is not empty and contains no links.
 	 *
 	 * @return void
 	 */
-	public function test_message_contains_learn_more_link() {
+	public function test_message_has_no_links() {
 		$notice = new Sunset_Notice();
-		$this->assertStringContainsString( Sunset_Notice::LEARN_MORE_URL, $notice->get_message() );
+		$this->assertNotEmpty( $notice->get_message() );
+		$this->assertStringNotContainsString( '<a ', $notice->get_message() );
 	}
 
 	/**
@@ -89,7 +90,7 @@ class Sunset_Notice_Test extends \WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'plugin-update-tr', $output );
 		$this->assertStringContainsString( 'notice-warning', $output );
-		$this->assertStringContainsString( Sunset_Notice::LEARN_MORE_URL, $output );
+		$this->assertStringContainsString( Sunset_Notice::CERTIFICATE_ACTION, $output );
 	}
 
 	/**

--- a/views/sunset-certificate.php
+++ b/views/sunset-certificate.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ * Standalone, print-optimized certificate page for the sunset notice.
+ *
+ * Rendered via admin-post.php, outside the WP admin chrome.
+ *
+ * @package Progress_Planner
+ */
+
+// Exit if accessed directly.
+if ( ! \defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$prpl_sunset_notice    = \progress_planner()->get_admin__sunset_notice();
+$prpl_completed_badges = $prpl_sunset_notice->get_completed_badges();
+$prpl_activation_date  = \progress_planner()->get_activation_date();
+$prpl_badge_svg_url    = \progress_planner()->get_remote_server_root_url() . '/wp-json/progress-planner-saas/v1/badge-svg/?badge_id=';
+
+// Scale the badges to the available space, so the certificate always fits on a single A4 page.
+$prpl_badge_count = \count( $prpl_completed_badges );
+if ( $prpl_badge_count <= 8 ) {
+	$prpl_badge_size = 24; // mm.
+} elseif ( $prpl_badge_count <= 18 ) {
+	$prpl_badge_size = 18;
+} elseif ( $prpl_badge_count <= 32 ) {
+	$prpl_badge_size = 14;
+} else {
+	$prpl_badge_size = 10;
+}
+
+?>
+<!DOCTYPE html>
+<html <?php \language_attributes(); ?>>
+<head>
+	<meta charset="<?php \bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php \esc_html_e( 'Progress Planner certificate', 'progress-planner' ); ?></title>
+	<style>
+		@page {
+			size: A4 landscape;
+			margin: 0;
+		}
+
+		* {
+			box-sizing: border-box;
+		}
+
+		body {
+			margin: 0;
+			padding: 2rem;
+			background: #f0f0f1;
+			font-family: -apple-system, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			color: #38296d;
+		}
+
+		.prpl-certificate {
+			width: 296mm;
+			height: 209mm;
+			margin: 0 auto;
+			background: #fff;
+			border: 4px solid #38296d;
+			outline: 2px solid #f9a310;
+			outline-offset: -12px;
+			padding: 12mm 18mm;
+			text-align: center;
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			overflow: hidden;
+		}
+
+		.prpl-certificate-logo svg,
+		.prpl-certificate-logo img {
+			max-width: 60mm;
+			max-height: 20mm;
+			height: auto;
+		}
+
+		.prpl-certificate h1 {
+			font-size: 9mm;
+			margin: 4mm 0 2mm;
+		}
+
+		.prpl-certificate .prpl-certificate-site {
+			font-size: 6mm;
+			margin: 2mm 0;
+		}
+
+		.prpl-certificate .prpl-certificate-site a {
+			color: #38296d;
+			text-decoration: none;
+		}
+
+		.prpl-certificate .prpl-certificate-since {
+			font-size: 4.5mm;
+			color: #50575e;
+			margin: 2mm 0 6mm;
+		}
+
+		.prpl-certificate-badges {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
+			align-content: center;
+			gap: 3mm 4mm;
+			margin: 0 0 6mm;
+			min-height: 0;
+		}
+
+		.prpl-certificate-badge {
+			width: <?php echo (float) ( $prpl_badge_size * 1.2 ); ?>mm;
+		}
+
+		.prpl-certificate-badge img {
+			width: <?php echo (float) $prpl_badge_size; ?>mm;
+			height: auto;
+		}
+
+		.prpl-certificate-badge span {
+			display: block;
+			font-size: 2.8mm;
+			margin-top: 1mm;
+		}
+
+		.prpl-certificate-footer {
+			font-size: 3.5mm;
+			color: #50575e;
+			margin: 0;
+		}
+
+		.prpl-certificate-print {
+			display: block;
+			margin: 2rem auto;
+			padding: 0.75rem 2rem;
+			font-size: 1rem;
+			color: #fff;
+			background: #dd324f;
+			border: none;
+			border-radius: 4px;
+			cursor: pointer;
+		}
+
+		@media print {
+			body {
+				background: #fff;
+				padding: 0;
+			}
+
+			.prpl-certificate {
+				margin: 0;
+				-webkit-print-color-adjust: exact;
+				print-color-adjust: exact;
+				page-break-inside: avoid;
+			}
+
+			.prpl-certificate-print {
+				display: none;
+			}
+		}
+	</style>
+</head>
+<body>
+	<div class="prpl-certificate">
+		<div class="prpl-certificate-logo">
+			<?php \progress_planner()->the_asset( 'images/logo_progress_planner.svg' ); ?>
+		</div>
+
+		<h1><?php \esc_html_e( 'Certificate of appreciation', 'progress-planner' ); ?></h1>
+
+		<p class="prpl-certificate-site">
+			<?php
+			\printf(
+				/* translators: %1$s: site name, %2$s: site URL (linked). */
+				\esc_html__( 'Proudly presented to %1$s (%2$s)', 'progress-planner' ),
+				'<strong>' . \esc_html( \get_bloginfo( 'name' ) ) . '</strong>',
+				'<a href="' . \esc_url( \home_url() ) . '">' . \esc_html( \home_url() ) . '</a>'
+			);
+			?>
+		</p>
+
+		<p class="prpl-certificate-since">
+			<?php
+			\printf(
+				/* translators: %s: the date the plugin was activated. */
+				\esc_html__( 'For working on this website with Progress Planner since %s.', 'progress-planner' ),
+				\esc_html( \date_i18n( (string) \get_option( 'date_format' ), (int) $prpl_activation_date->format( 'U' ) ) )
+			);
+			?>
+		</p>
+
+		<?php if ( ! empty( $prpl_completed_badges ) ) : ?>
+			<div class="prpl-certificate-badges">
+				<?php foreach ( $prpl_completed_badges as $prpl_badge ) : ?>
+					<div class="prpl-certificate-badge">
+						<img
+							src="<?php echo \esc_url( $prpl_badge_svg_url . $prpl_badge->get_id() ); ?>"
+							alt="<?php echo \esc_attr( $prpl_badge->get_name() ); ?>"
+							onerror="this.onerror=null;this.src='<?php echo \esc_url( \progress_planner()->get_placeholder_svg( 90, 90 ) ); ?>';"
+						>
+						<span><?php echo \esc_html( $prpl_badge->get_name() ); ?></span>
+					</div>
+				<?php endforeach; ?>
+			</div>
+		<?php endif; ?>
+
+		<p class="prpl-certificate-footer">
+			<?php \esc_html_e( 'Thank you for improving your website with us. — The Progress Planner team', 'progress-planner' ); ?>
+		</p>
+	</div>
+
+	<button class="prpl-certificate-print" onclick="window.print();">
+		<?php \esc_html_e( 'Save as PDF', 'progress-planner' ); ?>
+	</button>
+</body>
+</html>

--- a/views/sunset-notice.php
+++ b/views/sunset-notice.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Sunset notice banner for the Progress Planner dashboard.
+ *
+ * @package Progress_Planner
+ */
+
+// Exit if accessed directly.
+if ( ! \defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div class="prpl-widget-wrapper prpl-top-notice prpl-sunset-notice" id="prpl-sunset-notice">
+	<div class="inner-content">
+		<h1><?php \esc_html_e( 'Thank you for using Progress Planner!', 'progress-planner' ); ?></h1>
+		<p><?php echo \wp_kses_post( \progress_planner()->get_admin__sunset_notice()->get_message() ); ?></p>
+		<p><?php \esc_html_e( 'Want a keepsake? Download a printable certificate showing your website, how long you\'ve been improving it with Progress Planner, and all the badges you\'ve earned along the way.', 'progress-planner' ); ?></p>
+		<a class="prpl-button-primary" href="<?php echo \esc_url( \progress_planner()->get_admin__sunset_notice()->get_certificate_url() ); ?>" target="_blank" rel="noopener">
+			<?php \esc_html_e( 'Get your certificate', 'progress-planner' ); ?>
+		</a>
+	</div>
+</div>


### PR DESCRIPTION
## What

Shows a notice that support for the free plugin is ending, in two places:

- **Progress Planner dashboard**: a banner above the header (via the `progress_planner_admin_page_header_before` slot), thanking users and offering a certificate download.
- **Plugins overview page**: a warning row under the Progress Planner row, using WP core's own update-row markup (`plugin-update-tr` / `notice notice-warning inline notice-alt`) so it inherits core styling.

### Certificate

The "Get your certificate" button opens a standalone print-optimized page (served via `admin-post.php`, outside the admin chrome) showing the site name/URL, the date the user started using Progress Planner (`get_activation_date()`), and all completed badges across the content, maintenance, and monthly groups. A "Save as PDF" button triggers the browser print dialog. The layout is hard-sized to a single A4 landscape page; badge artwork scales with the badge count (24mm → 10mm tiers) so even 60+ badges fit on one sheet.

### Suppression for hosted users

The notice and certificate endpoint are not registered when:

- `PP_HOSTS_FILE` or `PROGRESS_PLANNER_BRANDING_ID` is defined, or the `PP_Hosts\Updater` class exists (pp-hosts active / host-defined branding), or
- the `pp-hosts` plugin is installed but inactive (`Plugin_Installer::is_plugin_installed()`).

A `progress_planner_show_sunset_notice` filter is available as an escape hatch (and as the test seam).

## Open items

- Badge artwork loads from the SaaS `badge-svg` endpoint at render time (with placeholder fallback); if that endpoint sunsets too, we may want to cache SVGs locally.

## Testing

- 6 new PHPUnit tests (hook registration, filter suppression, row-notice output, capability guards, completed-badge filtering, certificate output).
- PHPStan level 10, WPCS, and the full suite (414 tests) pass.
- Verified live in WP Playground: both notices render on a clean install; both disappear with `PROGRESS_PLANNER_BRANDING_ID` defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

