### PR TITLE
Prepare 1.9.2 release

### DIFF
--- a/progress-planner.php
+++ b/progress-planner.php
@@ -9,7 +9,7 @@
  * Description:       A plugin to help you fight procrastination and get things done.
  * Requires at least: 6.7
  * Requires PHP:      7.4
- * Version:           1.9.1
+ * Version:           1.9.2
  * Author:            Team Emilia Projects
  * Author URI:        https://prpl.fyi/about
  * License:           GPL-3.0+

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: planning, maintenance, writing, blogging
 Requires at least: 6.7
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 1.9.1
+Stable tag: 1.9.2
 License: GPL3+
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -82,6 +82,17 @@ https://youtu.be/e1bmxZYyXFY
 7. Get a weekly email with stats on how well you're doing on your site!
 
 == Changelog ==
+
+= 1.9.2 =
+
+Enhancements:
+
+* Strengthened capability and permission checks across the plugin.
+* Added 2026 monthly badge names.
+
+Maintenance:
+
+* Confirmed compatibility with WordPress 7.1.
 
 = 1.9.1 =
 


### PR DESCRIPTION
Bumps the plugin version to **1.9.2** and adds the changelog entry ahead of the `develop → main` release PR.

**Changes**
- `progress-planner.php`: `Version: 1.9.1 → 1.9.2`
- `readme.txt`: `Stable tag: 1.9.1 → 1.9.2` + new `= 1.9.2 =` changelog block

**Changelog entry**
- Strengthened capability and permission checks across the plugin.
- Added 2026 monthly badge names.
- Confirmed compatibility with WordPress 7.1.

The `develop → main` release PR will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)