### PR TITLE
Prepare 1.10.0 release

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -5,12 +5,12 @@
  * @package Progress_Planner
  */
 
+use Progress_Planner\Utils\Deprecations;
+
 // Exit if accessed directly.
 if ( ! \defined( 'ABSPATH' ) ) {
 	exit;
 }
-
-use Progress_Planner\Utils\Deprecations;
 
 // Require the Deprecations class.
 require_once __DIR__ . '/classes/utils/class-deprecations.php';

--- a/autoload.php
+++ b/autoload.php
@@ -5,6 +5,11 @@
  * @package Progress_Planner
  */
 
+// Exit if accessed directly.
+if ( ! \defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use Progress_Planner\Utils\Deprecations;
 
 // Require the Deprecations class.

--- a/autoload.php
+++ b/autoload.php
@@ -7,11 +7,6 @@
 
 use Progress_Planner\Utils\Deprecations;
 
-// Exit if accessed directly.
-if ( ! \defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 // Require the Deprecations class.
 require_once __DIR__ . '/classes/utils/class-deprecations.php';
 

--- a/classes/admin/class-page-settings.php
+++ b/classes/admin/class-page-settings.php
@@ -138,17 +138,6 @@ class Page_Settings {
 	}
 
 	/**
-	 * Save the redirect on login setting.
-	 *
-	 * @param bool $redirect_on_login Whether to redirect on login.
-	 *
-	 * @return void
-	 */
-	public function save_redirect_on_login( $redirect_on_login = false ) {
-		\update_user_meta( \get_current_user_id(), 'prpl_redirect_on_login', $redirect_on_login );
-	}
-
-	/**
 	 * Save the post types.
 	 *
 	 * @param array $post_types The post types.

--- a/classes/class-base.php
+++ b/classes/class-base.php
@@ -168,11 +168,6 @@ class Base {
 		// Plugin installer.
 		$this->get_plugin_installer();
 
-		/**
-		 * Redirect on login.
-		 */
-		\add_action( 'wp_login', [ $this, 'redirect_on_login' ], 10, 2 );
-
 		if ( \defined( 'WP_CLI' ) && \WP_CLI ) {
 			$this->get_wp_cli__get_stats_command();
 			$this->get_wp_cli__task_command();
@@ -513,34 +508,6 @@ class Base {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Redirect on login.
-	 *
-	 * @param string   $user_login The user login.
-	 * @param \WP_User $user The user object.
-	 *
-	 * @return void
-	 */
-	public function redirect_on_login( $user_login, $user ) {
-		// Check if the $user can `manage_options`.
-		if ( ! $user->has_cap( 'manage_options' ) ) {
-			return;
-		}
-
-		// Check if the user has the `prpl_redirect_on_login` meta.
-		if ( ! \get_user_meta( $user->ID, 'prpl_redirect_on_login', true ) ) {
-			return;
-		}
-
-		if ( isset( $_REQUEST['redirect_to'] ) && '' !== $_REQUEST['redirect_to'] && \admin_url( '/' ) !== $_REQUEST['redirect_to'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing -- We're not processing any data.
-			return;
-		}
-
-		// Redirect to the Progress Planner dashboard.
-		\wp_safe_redirect( \admin_url( 'admin.php?page=progress-planner' ) );
-		exit;
 	}
 
 	/**

--- a/classes/class-suggested-tasks.php
+++ b/classes/class-suggested-tasks.php
@@ -654,6 +654,8 @@ class Suggested_Tasks {
 	 * @return string
 	 */
 	public function get_task_id_from_slug( $slug ) {
-		return \explode( '__trashed', $slug )[0];
+		// Cast to string: callers may pass a null post_name/task_id, which would
+		// trigger a deprecation notice from explode() on PHP 8.1+.
+		return \explode( '__trashed', (string) $slug )[0];
 	}
 }

--- a/progress-planner.php
+++ b/progress-planner.php
@@ -9,7 +9,7 @@
  * Description:       A plugin to help you fight procrastination and get things done.
  * Requires at least: 6.7
  * Requires PHP:      7.4
- * Version:           1.9.1
+ * Version:           1.10.0
  * Author:            Team Emilia Projects
  * Author URI:        https://prpl.fyi/about
  * License:           GPL-3.0+

--- a/readme.txt
+++ b/readme.txt
@@ -95,6 +95,11 @@ Enhancements:
 * Strengthened capability and permission checks across the plugin.
 * Various performance improvements and code clean-up.
 
+Added these recommendations from Ravi:
+
+* Reduce the number of autoloaded options.
+* Set your About, Contact and FAQ pages.
+
 Maintenance:
 
 * Confirmed compatibility with WordPress 7.1.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: planning, maintenance, writing, blogging
 Requires at least: 6.7
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 1.9.1
+Stable tag: 1.10.0
 License: GPL3+
 License URI: https://www.gnu.org/licenses/gpl-3.0.en.html
 
@@ -82,6 +82,29 @@ https://youtu.be/e1bmxZYyXFY
 7. Get a weekly email with stats on how well you're doing on your site!
 
 == Changelog ==
+
+= 1.10.0 =
+
+Enhancements:
+
+* A brand-new onboarding experience for people setting up Progress Planner.
+* The Settings page is now handled through interactive tasks, in line with the rest of the plugin.
+* Recognize SureRank as an SEO plugin.
+* Show 3 suggested tasks on the WordPress Dashboard widget, and up to 5 on the Progress Planner page.
+* Added 2026 monthly badge names.
+* Strengthened capability and permission checks across the plugin.
+* Various performance improvements and code clean-up.
+
+Maintenance:
+
+* Confirmed compatibility with WordPress 7.1.
+
+Bugs we fixed:
+
+* Fix a year/week boundary calculation that could affect activity scoring.
+* Fix past badge points calculations.
+* Fix interactive task form re-submission after an error, and improve task completion checks.
+* Add safeguards to prevent fatal errors during plugin updates.
 
 = 1.9.1 =
 

--- a/views/dashboard-widgets/score.php
+++ b/views/dashboard-widgets/score.php
@@ -5,6 +5,11 @@
  * @package Progress_Planner
  */
 
+// Exit if accessed directly.
+if ( ! \defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use Progress_Planner\Badges\Monthly;
 
 $prpl_badge = Monthly::get_instance_from_id( Monthly::get_badge_id_from_date( new \DateTime() ) );

--- a/views/dashboard-widgets/todo.php
+++ b/views/dashboard-widgets/todo.php
@@ -5,6 +5,11 @@
  * @package Progress_Planner
  */
 
+// Exit if accessed directly.
+if ( ! \defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 ?>
 <div id="prpl-dashboard-widget-todo-header">
 	<span style="display:inline-flex;width:2.5em;height:2.5em;"><?php echo \progress_planner()->get_ui__branding()->get_admin_menu_icon( true ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- SVG markup. ?></span>


### PR DESCRIPTION
Prepares the 1.10.0 release ahead of the `develop → main` release PR (#695).

**Changes**
- `progress-planner.php`: `Version: 1.9.1 → 1.10.0`
- `readme.txt`: `Stable tag: 1.9.1 → 1.10.0` + new `= 1.10.0 =` changelog block (including the new Ravi recommendations: reduce autoloaded options, set About/Contact/FAQ pages).
- Removed dead login-redirect code left behind when the Settings page was converted to interactive tasks (the handler, its `wp_login` hook, and the unused setter). The user meta is still cleaned up by the 1.10.0 update migration.
- Fixed an `explode()` deprecation notice in `get_task_id_from_slug()` when a null slug is passed (PHP 8.1+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)